### PR TITLE
Added Circle Tickler to CI config file to join the docs pipeline

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,5 +31,6 @@ deployment:
       - gym --scheme "ios-sdk" --workspace "ios-sdk.xcworkspace" --output_directory $CIRCLE_ARTIFACTS
   docs_pipeline:
     branch: "migurski/add-to-docs-pipeline"
+    commands:
       - pip install 'Circle-Tickler == 1.0.1'
       - tickle-circle mapzen mapzen-docs-generator master $CIRCLE_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -32,5 +32,5 @@ deployment:
   docs_pipeline:
     branch: "migurski/add-to-docs-pipeline"
     commands:
-      - pip install 'Circle-Tickler == 1.0.1'
+      - sudo pip install 'Circle-Tickler == 1.0.1'
       - tickle-circle mapzen mapzen-docs-generator master $CIRCLE_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -29,8 +29,5 @@ deployment:
     branch: master
     commands: 
       - gym --scheme "ios-sdk" --workspace "ios-sdk.xcworkspace" --output_directory $CIRCLE_ARTIFACTS
-  docs_pipeline:
-    branch: "migurski/add-to-docs-pipeline"
-    commands:
       - sudo pip install 'Circle-Tickler == 1.0.1'
       - tickle-circle mapzen mapzen-docs-generator master $CIRCLE_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -29,5 +29,7 @@ deployment:
     branch: master
     commands: 
       - gym --scheme "ios-sdk" --workspace "ios-sdk.xcworkspace" --output_directory $CIRCLE_ARTIFACTS
+  docs_pipeline:
+    branch: "migurski/add-to-docs-pipeline"
       - pip install 'Circle-Tickler == 1.0.1'
       - tickle-circle mapzen mapzen-docs-generator master $CIRCLE_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,8 @@ machine:
     version: "8.0"
   environment:
     GYM_CODE_SIGNING_IDENTITY: "iPhone Distribution: Michael Cunningham (LTQC954SPQ)"
+  python:
+    version: 2.7.10
 
 dependencies:
   override:
@@ -29,3 +31,5 @@ deployment:
     branch: master
     commands: 
       - gym --scheme "ios-sdk" --workspace "ios-sdk.xcworkspace" --output_directory $CIRCLE_ARTIFACTS
+      - pip install 'Circle-Tickler == 1.0.1'
+      - tickle-circle mapzen mapzen-docs-generator master $CIRCLE_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,6 @@ machine:
     version: "8.0"
   environment:
     GYM_CODE_SIGNING_IDENTITY: "iPhone Distribution: Michael Cunningham (LTQC954SPQ)"
-  python:
-    version: 2.7.10
 
 dependencies:
   override:


### PR DESCRIPTION
This change adds iOS docs to Mapzen’s docs pipeline, so that successful master commits here trigger a fresh documentation publish process and no one needs to wait for docs to go live.

- [x] Add tickler to config
- [x] Test on a safe branch
- [x] Switch back to master branch

Part of https://github.com/mapzen/mapzen-docs-generator/issues/224.