### PR TITLE
Implement error handler to satisfy CLLocationManagerDelegate

### DIFF
--- a/ios-sdk/src/LocationManager.swift
+++ b/ios-sdk/src/LocationManager.swift
@@ -84,4 +84,8 @@ public class LocationManager: NSObject, CLLocationManagerDelegate {
         }
     }
 
+    public func locationManager(manager: CLLocationManager, didFailWithError error: NSError) {
+        print("Error from location manager: \(error)")
+    }
+
 }


### PR DESCRIPTION
Apparnetly delegates marked as optional may not really be optional.
If this method isn't implemented, requesting a location will cause a
crash.