### PR TITLE
Update podspec to 0.1.0 for release

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,10 +1,10 @@
-platform :ios, '9.0'
+platform :ios, '9.3'
 use_frameworks!
 
 def shared_pods
-  pod 'Pelias', :git => 'https://github.com/pelias/pelias-ios-sdk.git', :branch => 'master'
-  pod 'OnTheRoad', :git => 'https://github.com/mapzen/on-the-road_ios.git', :branch => 'master'
-  pod 'Tangram-es', :git => 'https://github.com/tangrams/ios-framework.git', :branch => 'master'
+  pod 'Pelias', '~> 1.0.0-beta'
+  pod 'OnTheRoad', '~> 1.0.0-beta'
+  pod 'Tangram-es', '~> 0.4'
 end
 
 target "ios-sdk" do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,40 +3,18 @@ PODS:
   - Pelias (1.0.0-beta3):
     - Pelias/Core (= 1.0.0-beta3)
   - Pelias/Core (1.0.0-beta3)
-  - Tangram-es (0.1.0)
+  - Tangram-es (0.4.0)
 
 DEPENDENCIES:
-  - OnTheRoad (from `https://github.com/mapzen/on-the-road_ios.git`, branch `master`)
-  - Pelias (from `https://github.com/pelias/pelias-ios-sdk.git`, branch `master`)
-  - Tangram-es (from `https://github.com/tangrams/ios-framework.git`, branch `master`)
-
-EXTERNAL SOURCES:
-  OnTheRoad:
-    :branch: master
-    :git: https://github.com/mapzen/on-the-road_ios.git
-  Pelias:
-    :branch: master
-    :git: https://github.com/pelias/pelias-ios-sdk.git
-  Tangram-es:
-    :branch: master
-    :git: https://github.com/tangrams/ios-framework.git
-
-CHECKOUT OPTIONS:
-  OnTheRoad:
-    :commit: 8b65272e369dfa07c1255eee6130a2df79b6da9e
-    :git: https://github.com/mapzen/on-the-road_ios.git
-  Pelias:
-    :commit: ba13625b8445c5b7a8b8de08b702fcf2425ad9c9
-    :git: https://github.com/pelias/pelias-ios-sdk.git
-  Tangram-es:
-    :commit: f7a96d812a27b012620cb5f63de4e770c01b85db
-    :git: https://github.com/tangrams/ios-framework.git
+  - OnTheRoad (~> 1.0.0-beta)
+  - Pelias (~> 1.0.0-beta)
+  - Tangram-es (~> 0.4)
 
 SPEC CHECKSUMS:
   OnTheRoad: 994e273d08efcfb598195f6235bf48d1e525602e
-  Pelias: 73fe42b321402cfe5beaeeb2dd4625ce897ffffe
-  Tangram-es: 0b836ead54f672545dc5bfcf0ae46e6f4b97c1ff
+  Pelias: 79a3ca6332a7cb48945b5d044f564b95f13a516e
+  Tangram-es: 49354b4ba6bbd180c2db90f79b4ed957f68e7525
 
-PODFILE CHECKSUM: c5f76346e1f9ed6d4fb353437cbb5c798f8f9061
+PODFILE CHECKSUM: d28cc38afbc26b27972877b46d3b976b73861b15
 
 COCOAPODS: 1.1.1

--- a/ios-sdk.podspec
+++ b/ios-sdk.podspec
@@ -1,27 +1,27 @@
 Pod::Spec.new do |s|
 
-  s.name    = 'ios-sdk'
+  s.name    = 'Mapzen-ios-sdk'
   s.version = '0.1.0'
 
   s.summary           = 'Mapzen iOS SDK'
-  s.description       = 'Mapzen iOS SDK'
+  s.description       = 'The Mapzen iOS SDK is a thin wrapper that packages up everything you need to use Mapzen services in your iOS applications. It also simplifies setup, installation, API key management, and generally makes your life better.'
   s.homepage          = 'https://mapzen.com/projects/mobile/'
-  s.license           = { :type => 'MIT', :file => 'LICENSE.md' }
+  s.license           = { :type => 'Apache License, Version 2.0', :file => 'LICENSE.md' }
   s.author            = { 'Mapzen' => 'ios-support@mapzen.com' }
   s.social_media_url  = 'https://twitter.com/mapzen'
   s.documentation_url = 'https://mapzen.com/documentation/ios/'
-  s.source           =  { :git => 'https://github.com/mapzen/ios.git', :branch => 'master' }
+  s.source           =  { :git => 'https://github.com/mapzen/ios.git', :tag => "v#{s.version}" }
 
   s.platform              = :ios
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '9.3'
 
   s.requires_arc = true
   s.default_subspec = 'Core'
 
   s.subspec 'Core' do |cs|
-    cs.dependency "Pelias"
-    cs.dependency "OnTheRoad"
-    cs.dependency "Tangram-es"
+    cs.dependency 'Pelias', '~> 1.0.0-beta'
+    cs.dependency 'OnTheRoad', '~> 1.0.0-beta'
+    cs.dependency 'Tangram-es', '~> 0.4'
     cs.source_files = "src/*.swift"
     cs.resources = 'images/*.png'
   end


### PR DESCRIPTION
Ideally given how the podspec dependencies are defined we shouldn't have to alter this podspec further as we update the beta releases of the underlying frameworks. 