### PR TITLE
Add back annotation tests

### DIFF
--- a/ios-sdkTests/MapViewControllerTests.swift
+++ b/ios-sdkTests/MapViewControllerTests.swift
@@ -129,41 +129,39 @@ class MapViewControllerTests: XCTestCase {
     XCTAssertTrue(controller.lastSetPointValue()?.longitude == mockLocation.coordinate.longitude)
   }
 
-  //TODO: Enable these once https://github.com/tangrams/tangram-es/issues/1220 gets resolved
+  func testAddAnnotations(){
+    let testAnno1 = PeliasMapkitAnnotation(coordinate: CLLocationCoordinate2DMake(0.0, 0.0), title: "Test1", subtitle: "SubTest1", data: nil)
+    let testAnno2 = PeliasMapkitAnnotation(coordinate: CLLocationCoordinate2DMake(1.0, 1.0), title: "Test2", subtitle: "SubTest2", data: nil)
+    let controller = MapViewController() // Grab local instance cuz we don't want to use mocks for these
+    let _ = try? controller.add([testAnno1, testAnno2])
 
-//  func testAddAnnotations(){
-//    let testAnno1 = PeliasMapkitAnnotation(coordinate: CLLocationCoordinate2DMake(0.0, 0.0), title: "Test1", subtitle: "SubTest1", data: nil)
-//    let testAnno2 = PeliasMapkitAnnotation(coordinate: CLLocationCoordinate2DMake(1.0, 1.0), title: "Test2", subtitle: "SubTest2", data: nil)
-//    let controller = MapViewController() // Grab local instance cuz we don't want to use mocks for these
-//    let _ = try? controller.add([testAnno1, testAnno2])
-//
-//    //Tests
-//    XCTAssertNotNil(controller.currentAnnotations[testAnno1])
-//    XCTAssertNotNil(controller.currentAnnotations[testAnno2])
-//
-//  }
-//
-//  func testRemoveSingleAnnotation(){
-//    let testAnno1 = PeliasMapkitAnnotation(coordinate: CLLocationCoordinate2DMake(0.0, 0.0), title: "Test1", subtitle: "SubTest1", data: nil)
-//    let controller = MapViewController() // Grab local instance cuz we don't want to use mocks for these
-//    let _ = try? controller.add([testAnno1])
-//
-//    //Tests
-//    let _ = try? controller.remove(testAnno1)
-//    XCTAssertNil(controller.currentAnnotations[testAnno1])
-//
-//  }
-//
-//  func testRemoveAllAnnotations(){
-//    let testAnno1 = PeliasMapkitAnnotation(coordinate: CLLocationCoordinate2DMake(0.0, 0.0), title: "Test1", subtitle: "SubTest1", data: nil)
-//    let testAnno2 = PeliasMapkitAnnotation(coordinate: CLLocationCoordinate2DMake(1.0, 1.0), title: "Test2", subtitle: "SubTest2", data: nil)
-//    let controller = MapViewController() // Grab local instance cuz we don't want to use mocks for these
-//    let _ = try? controller.add([testAnno1, testAnno2])
-//
-//    //Tests
-//    let _ = try? controller.removeAnnotations()
-//    XCTAssertNil(controller.currentAnnotations[testAnno1])
-//    XCTAssertNil(controller.currentAnnotations[testAnno2])
-//  }
+    //Tests
+    XCTAssertNotNil(controller.currentAnnotations[testAnno1])
+    XCTAssertNotNil(controller.currentAnnotations[testAnno2])
+
+  }
+
+  func testRemoveSingleAnnotation(){
+    let testAnno1 = PeliasMapkitAnnotation(coordinate: CLLocationCoordinate2DMake(0.0, 0.0), title: "Test1", subtitle: "SubTest1", data: nil)
+    let controller = MapViewController() // Grab local instance cuz we don't want to use mocks for these
+    let _ = try? controller.add([testAnno1])
+
+    //Tests
+    let _ = try? controller.remove(testAnno1)
+    XCTAssertNil(controller.currentAnnotations[testAnno1])
+
+  }
+
+  func testRemoveAllAnnotations(){
+    let testAnno1 = PeliasMapkitAnnotation(coordinate: CLLocationCoordinate2DMake(0.0, 0.0), title: "Test1", subtitle: "SubTest1", data: nil)
+    let testAnno2 = PeliasMapkitAnnotation(coordinate: CLLocationCoordinate2DMake(1.0, 1.0), title: "Test2", subtitle: "SubTest2", data: nil)
+    let controller = MapViewController() // Grab local instance cuz we don't want to use mocks for these
+    let _ = try? controller.add([testAnno1, testAnno2])
+
+    //Tests
+    let _ = try? controller.removeAnnotations()
+    XCTAssertNil(controller.currentAnnotations[testAnno1])
+    XCTAssertNil(controller.currentAnnotations[testAnno2])
+  }
 
 }


### PR DESCRIPTION
I verified the tests pass and run with the following:
1. Set target to simulator
2. Run tests with `⌘U`
3. Receive output:
```
Test Suite 'All tests' started at 2017-02-13 15:46:06.336
Test Suite 'ios-sdkTests.xctest' started at 2017-02-13 15:46:06.337
Test Suite 'MapViewControllerTests' started at 2017-02-13 15:46:06.337
Test Case '-[ios_sdkTests.MapViewControllerTests testAddAnnotations]' started.
Test Case '-[ios_sdkTests.MapViewControllerTests testAddAnnotations]' passed (0.034 seconds).
Test Case '-[ios_sdkTests.MapViewControllerTests testDisableLocation]' started.
Test Case '-[ios_sdkTests.MapViewControllerTests testDisableLocation]' passed (0.004 seconds).
Test Case '-[ios_sdkTests.MapViewControllerTests testEnableLocation]' started.
Test Case '-[ios_sdkTests.MapViewControllerTests testEnableLocation]' passed (0.008 seconds).
Test Case '-[ios_sdkTests.MapViewControllerTests testFindMeButtonInitialState]' started.
Test Case '-[ios_sdkTests.MapViewControllerTests testFindMeButtonInitialState]' passed (0.007 seconds).
Test Case '-[ios_sdkTests.MapViewControllerTests testInit]' started.
Test Case '-[ios_sdkTests.MapViewControllerTests testInit]' passed (0.014 seconds).
Test Case '-[ios_sdkTests.MapViewControllerTests testInitialLocationState]' started.
Test Case '-[ios_sdkTests.MapViewControllerTests testInitialLocationState]' passed (0.002 seconds).
Test Case '-[ios_sdkTests.MapViewControllerTests testLocationUpdateSansMarkerGeneration]' started.
Test Case '-[ios_sdkTests.MapViewControllerTests testLocationUpdateSansMarkerGeneration]' passed (0.006 seconds).
Test Case '-[ios_sdkTests.MapViewControllerTests testLocationUpdateWithMarkerGeneration]' started.
Test Case '-[ios_sdkTests.MapViewControllerTests testLocationUpdateWithMarkerGeneration]' passed (0.009 seconds).
Test Case '-[ios_sdkTests.MapViewControllerTests testRemoveAllAnnotations]' started.
Test Case '-[ios_sdkTests.MapViewControllerTests testRemoveAllAnnotations]' passed (0.006 seconds).
Test Case '-[ios_sdkTests.MapViewControllerTests testRemoveSingleAnnotation]' started.
Test Case '-[ios_sdkTests.MapViewControllerTests testRemoveSingleAnnotation]' passed (0.004 seconds).
Test Case '-[ios_sdkTests.MapViewControllerTests testShowCurrentLocation]' started.
Test Case '-[ios_sdkTests.MapViewControllerTests testShowCurrentLocation]' passed (0.003 seconds).
Test Case '-[ios_sdkTests.MapViewControllerTests testShowFindMeButton]' started.
Test Case '-[ios_sdkTests.MapViewControllerTests testShowFindMeButton]' passed (0.002 seconds).
Test Suite 'MapViewControllerTests' passed at 2017-02-13 15:46:06.450.
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.099 (0.112) seconds
Test Suite 'MapzenManagerTests' started at 2017-02-13 15:46:06.450
Test Case '-[ios_sdkTests.MapzenManagerTests testApiKeyMapNotSet]' started.
TANGRAM tangram.cpp:186: Loading scene file: someYamlThing.yaml
WARNING sceneLoader.cpp:186: No source defined in the yaml scene configuration.
Test Case '-[ios_sdkTests.MapzenManagerTests testApiKeyMapNotSet]' passed (0.027 seconds).
Test Case '-[ios_sdkTests.MapzenManagerTests testApiKeyMapSet]' started.
TANGRAM tangram.cpp:186: Loading scene file: someYamlThing.yaml
WARNING sceneLoader.cpp:186: No source defined in the yaml scene configuration.
TANGRAM tangram.cpp:269: Applying 1 scene updates
Test Case '-[ios_sdkTests.MapzenManagerTests testApiKeyMapSet]' passed (0.005 seconds).
WARNING sceneLoader.cpp:186: No source defined in the yaml scene configuration.
Test Case '-[ios_sdkTests.MapzenManagerTests testApiKeyRouteNotSet]' started.
Test Case '-[ios_sdkTests.MapzenManagerTests testApiKeyRouteNotSet]' passed (0.001 seconds).
Test Case '-[ios_sdkTests.MapzenManagerTests testApiKeyRouteSet]' started.
Test Case '-[ios_sdkTests.MapzenManagerTests testApiKeyRouteSet]' passed (0.002 seconds).
Test Case '-[ios_sdkTests.MapzenManagerTests testApiKeySearch]' started.
Test Case '-[ios_sdkTests.MapzenManagerTests testApiKeySearch]' passed (0.001 seconds).
Test Case '-[ios_sdkTests.MapzenManagerTests testSingleton]' started.
Test Case '-[ios_sdkTests.MapzenManagerTests testSingleton]' passed (0.000 seconds).
Test Suite 'MapzenManagerTests' passed at 2017-02-13 15:46:06.501.
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.037 (0.050) seconds
Test Suite 'ios-sdkTests.xctest' passed at 2017-02-13 15:46:06.503.
	 Executed 18 tests, with 0 failures (0 unexpected) in 0.136 (0.166) seconds
Test Suite 'All tests' passed at 2017-02-13 15:46:06.505.
	 Executed 18 tests, with 0 failures (0 unexpected) in 0.136 (0.169) seconds
```

Closes #142 