### PR TITLE
Wrap TGMapViewController

### DIFF
--- a/ios-sdk.xcodeproj/project.pbxproj
+++ b/ios-sdk.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7DF0AA2E1E5520ED00B0406E /* TestTGMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF0AA2D1E5520ED00B0406E /* TestTGMapViewController.swift */; };
 		AC586709D7E7D4C22AA9474D /* Pods_ios_sdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99B3EC60450343448FA4E699 /* Pods_ios_sdk.framework */; };
 		C8F52AC1BCE46BB17E1CE0A5 /* Pods_ios_sdkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A3EA87256F2EA6D0C43260A /* Pods_ios_sdkTests.framework */; };
 		DB188EEA1E2846600054DEFD /* MapzenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB188EE91E2846600054DEFD /* MapzenManager.swift */; };
@@ -70,6 +71,7 @@
 /* Begin PBXFileReference section */
 		0A9FDCBA6C81C063BED6CDFF /* Pods-ios-sdk.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-sdk.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios-sdk/Pods-ios-sdk.release.xcconfig"; sourceTree = "<group>"; };
 		5A3EA87256F2EA6D0C43260A /* Pods_ios_sdkTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ios_sdkTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7DF0AA2D1E5520ED00B0406E /* TestTGMapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTGMapViewController.swift; sourceTree = "<group>"; };
 		92C35E8790FB3255237B1E77 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		99B3EC60450343448FA4E699 /* Pods_ios_sdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ios_sdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A8BB69C349D7314906580508 /* Pods-ios-sdkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-sdkTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios-sdkTests/Pods-ios-sdkTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 				DB7A33EE1C8F8E8B009CC743 /* Info.plist */,
 				DBCBC5BE1E0AE1CF0045B345 /* MapViewControllerTests.swift */,
 				DB188EEB1E28492A0054DEFD /* MapzenManagerTests.swift */,
+				7DF0AA2D1E5520ED00B0406E /* TestTGMapViewController.swift */,
 			);
 			path = "ios-sdkTests";
 			sourceTree = "<group>";
@@ -496,6 +499,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7DF0AA2E1E5520ED00B0406E /* TestTGMapViewController.swift in Sources */,
 				DB188EEC1E28492A0054DEFD /* MapzenManagerTests.swift in Sources */,
 				DBCBC5BF1E0AE1CF0045B345 /* MapViewControllerTests.swift in Sources */,
 			);

--- a/ios-sdkTests/MapViewControllerTests.swift
+++ b/ios-sdkTests/MapViewControllerTests.swift
@@ -21,10 +21,6 @@ class TestMapViewController: MapViewController {
   func shouldShowCurrentLocationValue() -> Bool {
     return shouldShowCurrentLocation
   }
-  override func markerAdd() -> TGMapMarkerId {
-    //Mocked out to always return a valid ID
-    return 1
-  }
 }
 
 class MockHTTPHandler: TGHttpHandler {
@@ -36,19 +32,197 @@ class MockHTTPHandler: TGHttpHandler {
 class MapViewControllerTests: XCTestCase {
 
   var controller = TestMapViewController()
+  var tgViewController = TestTGMapViewController()
   let mockLocation = CLLocation(latitude: 0.0, longitude: 0.0) // Null Island!
 
   override func setUp() {
-    controller = TestMapViewController()
+    controller.tgViewController = tgViewController
     let mockHTTP = MockHTTPHandler()
-    controller.httpHandler = mockHTTP
+    controller.tgViewController.httpHandler = mockHTTP
   }
 
   func testInit() {
     XCTAssertNotNil(controller)
     XCTAssertFalse(controller.shouldFollowCurrentLocation)
   }
+  
+  func testAnimateToPosition() {
+    let point = TGGeoPoint(longitude: 70.0, latitude: 40.0)
+    controller.animateToPosition(point, withDuration: 3)
+    XCTAssertEqual(tgViewController.coordinate.longitude, 70.0)
+    XCTAssertEqual(tgViewController.coordinate.latitude, 40.0)
+    XCTAssertEqual(tgViewController.duration, 3)
+  }
+  
+  func testAnimateToPositionWithEase() {
+    let point = TGGeoPoint(longitude: 70.0, latitude: 40.0)
+    controller.animateToPosition(point, withDuration: 3, withEaseType: TGEaseType.Cubic)
+    XCTAssertEqual(tgViewController.coordinate.longitude, 70.0)
+    XCTAssertEqual(tgViewController.coordinate.latitude, 40.0)
+    XCTAssertEqual(tgViewController.duration, 3)
+    XCTAssertEqual(tgViewController.easeType, TGEaseType.Cubic)
+  }
 
+  func testAnimateToZoom() {
+    controller.animateToZoomLevel(1.0, withDuration: 2.0)
+    XCTAssertEqual(tgViewController.zoom, 1.0)
+    XCTAssertEqual(tgViewController.duration, 2.0)
+  }
+
+  func testAnimateToZoomWithEase() {
+    controller.animateToZoomLevel(1.0, withDuration: 2.0, withEaseType: TGEaseType.Cubic)
+    XCTAssertEqual(tgViewController.zoom, 1.0)
+    XCTAssertEqual(tgViewController.duration, 2.0)
+    XCTAssertEqual(tgViewController.easeType, TGEaseType.Cubic)
+  }
+  
+  func testAnimateToRotation() {
+    controller.animateToRotation(1.0, withDuration: 9.0)
+    XCTAssertEqual(tgViewController.rotation, 1.0)
+    XCTAssertEqual(tgViewController.duration, 9.0)
+  }
+  
+  func testAnimateToRotationWithEase() {
+    controller.animateToRotation(1.0, withDuration: 9.0, withEaseType: TGEaseType.Linear)
+    XCTAssertEqual(tgViewController.rotation, 1.0)
+    XCTAssertEqual(tgViewController.duration, 9.0)
+    XCTAssertEqual(tgViewController.easeType, TGEaseType.Linear)
+  }
+  
+  func testAnimateToTilt() {
+    controller.animateToTilt(3.0, withDuration: 4.0)
+    XCTAssertEqual(tgViewController.tilt, 3.0)
+    XCTAssertEqual(tgViewController.duration, 4.0)
+  }
+  
+  func testAnimateToTiltWithEase() {
+    controller.animateToTilt(3.0, withDuration: 4.0, withEaseType: TGEaseType.Sine)
+    XCTAssertEqual(tgViewController.tilt, 3.0)
+    XCTAssertEqual(tgViewController.duration, 4.0)
+    XCTAssertEqual(tgViewController.easeType, TGEaseType.Sine)
+  }
+  
+  func testMarkerRemoveAll() {
+    controller.markerRemoveAll()
+    XCTAssertTrue(tgViewController.removedAllMarkers)
+  }
+
+  func testMarkerAdd() {
+    controller.markerAdd()
+    XCTAssertTrue(tgViewController.addedMarker)
+  }
+  
+  func testMarkerSetStyling() {
+    controller.markerSetStyling(8, styling: "styling")
+    XCTAssertEqual(tgViewController.currMarkerId, 8)
+    XCTAssertEqual(tgViewController.styling, "styling")
+  }
+  
+  func testMarkerSetPoint() {
+    let point = TGGeoPoint(longitude: 70.0, latitude: 40.0)
+    controller.markerSetPoint(8, coordinates: point)
+    XCTAssertEqual(tgViewController.currMarkerId, 8)
+    XCTAssertEqual(tgViewController.coordinate.longitude, 70.0)
+    XCTAssertEqual(tgViewController.coordinate.latitude, 40.0)
+  }
+  
+  func testMarkerSetPointWithEase() {
+    let point = TGGeoPoint(longitude: 70.0, latitude: 40.0)
+    controller.markerSetPointEased(8, coordinates: point, duration: 7, easeType: TGEaseType.Cubic)
+    XCTAssertEqual(tgViewController.currMarkerId, 8)
+    XCTAssertEqual(tgViewController.coordinate.longitude, 70.0)
+    XCTAssertEqual(tgViewController.coordinate.latitude, 40.0)
+    XCTAssertEqual(tgViewController.duration, 7)
+    XCTAssertEqual(tgViewController.easeType, TGEaseType.Cubic)
+  }
+  
+  func testMarkerSetPolyline() {
+    let line = TGGeoPolyline()
+    controller.markerSetPolyline(1, polyline: line)
+    XCTAssertEqual(tgViewController.currMarkerId, 1)
+    XCTAssertEqual(tgViewController.polyline, line)
+  }
+  
+  func testMarkerSetPolygon() {
+    let polygon = TGGeoPolygon()
+    controller.markerSetPolygon(1, polygon: polygon)
+    XCTAssertEqual(tgViewController.currMarkerId, 1)
+    XCTAssertEqual(tgViewController.polygon, polygon)
+  }
+  
+  func testMarkerSetVisible() {
+    controller.markerSetVisible(2, visible: true)
+    XCTAssertEqual(tgViewController.currMarkerId, 2)
+    XCTAssertTrue(tgViewController.markerVisible)
+  }
+  
+  func testMarkerSetImage() {
+    let image = UIImage()
+    controller.markerSetImage(4, image: image)
+    XCTAssertEqual(tgViewController.currMarkerId, 4)
+    XCTAssertEqual(tgViewController.markerImage, image)
+  }
+  
+  func testMarkerRemove() {
+    controller.markerRemove(5)
+    XCTAssertEqual(tgViewController.currMarkerId, 5)
+  }
+  
+  func testLoadSceneFile() {
+    controller.loadSceneFile("path")
+    XCTAssertEqual(tgViewController.scenePath, "path")
+  }
+  
+  func testLoadSceneFileWithUpdates() {
+    let updates = [TGSceneUpdate]()
+    controller.loadSceneFile("path", sceneUpdates: updates)
+    XCTAssertEqual(tgViewController.scenePath, "path")
+    XCTAssertEqual(tgViewController.sceneUpdates, updates)
+  }
+  
+  func testLoadSceneFileAsync() {
+    controller.loadSceneFileAsync("path")
+    XCTAssertEqual(tgViewController.scenePath, "path")
+  }
+
+  func testLoadSceneFileAsyncWithUpdates() {
+    let updates = [TGSceneUpdate]()
+    controller.loadSceneFileAsync("path", sceneUpdates: updates)
+    XCTAssertEqual(tgViewController.scenePath, "path")
+    XCTAssertEqual(tgViewController.sceneUpdates, updates)
+  }
+
+  func testQueueSceneUpdate() {
+    controller.queueSceneUpdate("path", withValue: "value")
+    XCTAssertEqual(tgViewController.sceneUpdateComponentPath, "path")
+    XCTAssertEqual(tgViewController.sceneUpdateValue, "value")
+  }
+
+  func testQueueSceneUpdates() {
+    let updates = [TGSceneUpdate]()
+    controller.queueSceneUpdates(updates)
+    XCTAssertEqual(tgViewController.sceneUpdates, updates)
+    
+  }
+  
+  func testApplySceneUpdates() {
+    controller.applySceneUpdates()
+    XCTAssertTrue(tgViewController.appliedSceneUpdates)
+  }
+
+  func testLngLatToScreenPosition() {
+    let point = TGGeoPointMake(70.0, 40.0)
+    controller.lngLatToScreenPosition(point)
+    XCTAssertEqual(tgViewController.lngLatForScreenPosition.longitude, 70.0)
+    XCTAssertEqual(tgViewController.lngLatForScreenPosition.latitude, 40.0)
+  }
+
+  func testScreenPositionToLngLat() {
+    let point = CGPointMake(1, 2)
+    controller.screenPositionToLngLat(point)
+    XCTAssertEqual(tgViewController.screenPositionForLngLat, point)
+  }
+  
   func testFindMeButtonInitialState() {
     //Test Initial State
     XCTAssertTrue(controller.findMeButton.hidden)

--- a/ios-sdkTests/TestTGMapViewController.swift
+++ b/ios-sdkTests/TestTGMapViewController.swift
@@ -1,0 +1,176 @@
+//
+//  TestTGMapViewController.swift
+//  ios-sdk
+//
+//  Created by Sarah Lensing on 2/15/17.
+//  Copyright © 2017 Mapzen. All rights reserved.
+//
+
+import Foundation
+import TangramMap
+
+class TestTGMapViewController: TGMapViewController {
+  
+  var removedAllMarkers = false
+  var addedMarker = false
+  var currMarkerId: TGMapMarkerId = 0
+  var styling = ""
+  var coordinate = TGGeoPoint()
+  var duration: Float = 0.0
+  var easeType = TGEaseType.Cubic
+  var polyline = TGGeoPolyline()
+  var polygon = TGGeoPolygon()
+  var markerVisible = false
+  var markerImage = UIImage()
+  var scenePath = ""
+  var sceneUpdates: [TGSceneUpdate] = []
+  var sceneUpdateComponentPath = ""
+  var sceneUpdateValue = ""
+  var appliedSceneUpdates = false
+  var lngLatForScreenPosition = TGGeoPoint()
+  var screenPositionForLngLat = CGPoint()
+  
+  override func markerRemoveAll() {
+    removedAllMarkers = true
+  }
+  
+  override func markerAdd() -> TGMapMarkerId {
+    addedMarker = true
+    return 1
+  }
+  
+  override func markerSetStyling(identifier: TGMapMarkerId, styling: String) -> Bool {
+    self.currMarkerId = identifier
+    self.styling = styling
+    return true
+  }
+  
+  override func markerSetPoint(identifier: TGMapMarkerId, coordinates coordinate: TGGeoPoint) -> Bool {
+    self.currMarkerId = identifier
+    self.coordinate = coordinate
+    return true
+  }
+  
+  override func markerSetPointEased(identifier: TGMapMarkerId, coordinates coordinate: TGGeoPoint, duration: Float, easeType ease: TGEaseType) -> Bool {
+    self.currMarkerId = identifier
+    self.coordinate = coordinate
+    self.duration = duration
+    self.easeType = ease
+    return true
+  }
+  
+  override func markerSetPolyline(identifier: TGMapMarkerId, polyline: TGGeoPolyline) -> Bool {
+    self.currMarkerId = identifier
+    self.polyline = polyline
+    return true
+  }
+  
+  override func markerSetPolygon(identifier: TGMapMarkerId, polygon: TGGeoPolygon) -> Bool {
+    self.currMarkerId = identifier
+    self.polygon = polygon
+    return true
+  }
+  
+  override func markerSetVisible(identifier: TGMapMarkerId, visible: Bool) -> Bool {
+    self.currMarkerId = identifier
+    self.markerVisible = visible
+    return true
+  }
+  
+  override func markerSetImage(identifier: TGMapMarkerId, image: UIImage) -> Bool {
+    self.currMarkerId = identifier
+    self.markerImage = image
+    return true
+  }
+  
+  override func markerRemove(marker: TGMapMarkerId) -> Bool {
+    self.currMarkerId = marker
+    return true
+  }
+  
+  override func loadSceneFile(path: String) {
+    self.scenePath = path
+  }
+  
+  override func loadSceneFile(path: String, sceneUpdates: [TGSceneUpdate]) {
+    self.scenePath = path
+    self.sceneUpdates = sceneUpdates
+  }
+  
+  override func loadSceneFileAsync(path: String) {
+    self.scenePath = path
+  }
+  
+  override func loadSceneFileAsync(path: String, sceneUpdates: [TGSceneUpdate]) {
+    self.scenePath = path
+    self.sceneUpdates = sceneUpdates
+  }
+  
+  override func queueSceneUpdate(componentPath: String, withValue value: String) {
+    self.sceneUpdateComponentPath = componentPath
+    self.sceneUpdateValue = value
+  }
+  
+  override func queueSceneUpdates(sceneUpdates: [TGSceneUpdate]) {
+    self.sceneUpdates = sceneUpdates
+  }
+  
+  override func applySceneUpdates() {
+    self.appliedSceneUpdates = true
+  }
+  
+  override func lngLatToScreenPosition(lngLat: TGGeoPoint) -> CGPoint {
+    self.lngLatForScreenPosition = lngLat
+    return CGPoint()
+  }
+  
+  override func screenPositionToLngLat(screenPosition: CGPoint) -> TGGeoPoint {
+    self.screenPositionForLngLat = screenPosition
+    return TGGeoPoint()
+  }
+  
+  override func animateToPosition(position: TGGeoPoint, withDuration seconds: Float) {
+    self.coordinate = position
+    self.duration = seconds
+  }
+  
+  override func animateToPosition(position: TGGeoPoint, withDuration seconds: Float, withEaseType easeType: TGEaseType) {
+    self.coordinate = position
+    self.duration = seconds
+    self.easeType = easeType
+  }
+  
+  override func animateToZoomLevel(zoomLevel: Float, withDuration seconds: Float) {
+    self.zoom = zoomLevel
+    self.duration = seconds
+  }
+  
+  override func animateToZoomLevel(zoomLevel: Float, withDuration seconds: Float, withEaseType easeType: TGEaseType) {
+    self.zoom = zoomLevel
+    self.duration = seconds
+    self.easeType = easeType
+  }
+  
+  override func animateToRotation(radians: Float, withDuration seconds: Float) {
+    self.rotation = radians
+    self.duration = seconds
+  }
+  
+  override func animateToRotation(radians: Float, withDuration seconds: Float, withEaseType easeType: TGEaseType) {
+    self.rotation = radians
+    self.duration = seconds
+    self.easeType = easeType
+  }
+  
+  override func animateToTilt(radians: Float, withDuration seconds: Float) {
+    self.tilt = radians
+    self.duration = seconds
+  }
+  
+  override func animateToTilt(radians: Float, withDuration seconds: Float, withEaseType easeType: TGEaseType) {
+    self.tilt = radians
+    self.duration = seconds
+    self.easeType = easeType
+  }
+
+}

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -31,6 +31,51 @@ public class MapViewController: UIViewController, LocationManagerDelegate, TGRec
   public var findMeButton = UIButton(type: .Custom)
   public var currentAnnotations: [PeliasMapkitAnnotation : TGMapMarkerId] = Dictionary()
 
+  public var cameraType: TGCameraType {
+    set {
+      tgViewController.cameraType = cameraType
+    }
+    get {
+      return tgViewController.cameraType
+    }
+  }
+  
+  public var position: TGGeoPoint {
+    set {
+      tgViewController.position = position
+    }
+    get {
+      return tgViewController.position
+    }
+  }
+  
+  public var zoom: Float {
+    set {
+      tgViewController.zoom = zoom
+    }
+    get {
+      return tgViewController.zoom
+    }
+  }
+  
+  public var rotation: Float {
+    set {
+      tgViewController.rotation = rotation
+    }
+    get {
+      return tgViewController.rotation
+    }
+  }
+  
+  public var tilt: Float {
+    set {
+      tgViewController.tilt = tilt
+    }
+    get {
+      return tgViewController.tilt
+    }
+  }
+
   init(){
     super.init(nibName: nil, bundle: nil)
     defer {
@@ -45,6 +90,114 @@ public class MapViewController: UIViewController, LocationManagerDelegate, TGRec
     }
   }
 
+  public func animateToPosition(position: TGGeoPoint, withDuration seconds: Float) {
+    tgViewController.animateToPosition(position, withDuration: seconds)
+  }
+  
+  public func animateToPosition(position: TGGeoPoint, withDuration seconds: Float, withEaseType easeType: TGEaseType) {
+    tgViewController.animateToPosition(position, withDuration: seconds, withEaseType: easeType)
+  }
+  
+  public func animateToZoomLevel(zoomLevel: Float, withDuration seconds: Float) {
+    tgViewController.animateToZoomLevel(zoomLevel, withDuration: seconds)
+  }
+  
+  public func animateToZoomLevel(zoomLevel: Float, withDuration seconds: Float, withEaseType easeType: TGEaseType) {
+    tgViewController.animateToZoomLevel(zoomLevel, withDuration: seconds, withEaseType: easeType)
+  }
+  
+  public func animateToRotation(radians: Float, withDuration seconds: Float) {
+    tgViewController.animateToRotation(radians, withDuration: seconds)
+  }
+  
+  public func animateToRotation(radians: Float, withDuration seconds: Float, withEaseType easeType: TGEaseType) {
+    tgViewController.animateToRotation(radians, withDuration: seconds, withEaseType: easeType)
+  }
+  
+  public func animateToTilt(radians: Float, withDuration seconds: Float) {
+    tgViewController.animateToTilt(radians, withDuration: seconds)
+  }
+  
+  public func animateToTilt(radians: Float, withDuration seconds: Float, withEaseType easeType: TGEaseType) {
+    tgViewController.animateToTilt(radians, withDuration: seconds, withEaseType: easeType)
+  }
+  
+  public func markerRemoveAll() {
+    tgViewController.markerRemoveAll()
+  }
+  
+  public func markerAdd() -> TGMapMarkerId {
+    return tgViewController.markerAdd()
+  }
+  
+  public func markerSetStyling(identifier: TGMapMarkerId, styling: String) -> Bool {
+    return tgViewController.markerSetStyling(identifier, styling: styling)
+  }
+  
+  public func markerSetPoint(identifier: TGMapMarkerId, coordinates coordinate: TGGeoPoint) -> Bool {
+    return tgViewController.markerSetPoint(identifier, coordinates: coordinate)
+  }
+  
+  public func markerSetPointEased(identifier: TGMapMarkerId, coordinates coordinate: TGGeoPoint, duration: Float, easeType ease: TGEaseType) -> Bool {
+    return tgViewController.markerSetPointEased(identifier, coordinates: coordinate, duration: duration, easeType: ease)
+  }
+  
+  public func markerSetPolyline(identifier: TGMapMarkerId, polyline: TGGeoPolyline) -> Bool {
+    return tgViewController.markerSetPolyline(identifier, polyline: polyline)
+  }
+  
+  public func markerSetPolygon(identifier: TGMapMarkerId, polygon: TGGeoPolygon) -> Bool {
+    return tgViewController.markerSetPolygon(identifier, polygon: polygon)
+  }
+  
+  public func markerSetVisible(identifier: TGMapMarkerId, visible: Bool) -> Bool {
+    return tgViewController.markerSetVisible(identifier, visible: visible)
+  }
+  
+  public func markerSetImage(identifier: TGMapMarkerId, image: UIImage) -> Bool {
+    return tgViewController.markerSetImage(identifier, image: image)
+  }
+  
+  public func markerRemove(marker: TGMapMarkerId) -> Bool {
+    return tgViewController.markerRemove(marker)
+  }
+  
+  public func loadSceneFile(path: String) {
+    tgViewController.loadSceneFile(path)
+  }
+  
+  public func loadSceneFile(path: String, sceneUpdates: [TGSceneUpdate]) {
+    tgViewController.loadSceneFile(path, sceneUpdates: sceneUpdates)
+  }
+  
+  public func loadSceneFileAsync(path: String) {
+    tgViewController.loadSceneFileAsync(path)
+  }
+  
+  public func loadSceneFileAsync(path: String, sceneUpdates: [TGSceneUpdate]) {
+    tgViewController.loadSceneFileAsync(path, sceneUpdates: sceneUpdates)
+  }
+  
+  public func queueSceneUpdate(componentPath: String, withValue value: String) {
+    tgViewController.queueSceneUpdate(componentPath, withValue: value)
+  }
+  
+  public func queueSceneUpdates(sceneUpdates: [TGSceneUpdate]) {
+    tgViewController.queueSceneUpdates(sceneUpdates)
+  }
+  
+  public func applySceneUpdates() {
+    tgViewController.applySceneUpdates()
+  }
+  
+  public func lngLatToScreenPosition(lngLat: TGGeoPoint) -> CGPoint {
+    return tgViewController.lngLatToScreenPosition(lngLat)
+  }
+  
+  public func screenPositionToLngLat(screenPosition: CGPoint) -> TGGeoPoint {
+    return tgViewController.screenPositionToLngLat(screenPosition)
+  }
+  
   //! Returns whether or not the map was centered on the device's current location
   public func resetCameraOnCurrentLocation(tilt: Float = 0.0, zoomLevel: Float = 16.0, animationDuration: Float = 1.0) -> Bool {
     guard let marker = currentLocationGem else { return false }

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -193,10 +193,17 @@ public class MapViewController: UIViewController, LocationManagerDelegate, TGRec
   override public func viewDidLoad() {
     super.viewDidLoad()
     LocationManager.sharedManager.delegate = self
+    
     self.view.addSubview(tgViewController.view)
+    
     tgViewController.gestureDelegate = self
   }
 
+  override public func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+    super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
+    tgViewController.viewWillTransitionToSize(size, withTransitionCoordinator:coordinator)
+  }
+    
   override public func viewWillAppear(animated: Bool) {
     super.viewWillAppear(animated)
     let viewRect = view.bounds

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -22,7 +22,7 @@ public class MapViewController: UIViewController, LocationManagerDelegate, TGRec
   //Error Domains for NSError Appeasement
   public static let MapzenGeneralErrorDomain = "MapzenGeneralErrorDomain"
   
-  var tgViewController: TGMapViewController = TGMapViewController()
+  public var tgViewController: TGMapViewController = TGMapViewController()
   var currentLocationGem: TGMapMarkerId?
   var lastSetPoint: TGGeoPoint?
   var shouldShowCurrentLocation = false


### PR DESCRIPTION
This PR updates the SDK's main map entry point `MapViewController` so that it wraps `TGMapViewController`

- `MapViewController` now creates an instance of `TGMapViewController` and adds its view as a subview
- Most of the `TGMapViewController` methods have been added to `MapViewController`s interface and forward calls to the internal `TGMapViewController`
- Methods that have been excluded from `MapViewController` include:
```
public func pickFeatureAt(screenPosition: CGPoint)
public func pickLabelAt(screenPosition: CGPoint)
public func pickMarkerAt(screenPosition: CGPoint)
public func setPickRadius(logicalPixels: Float)
public func requestRender()
public func renderOnce()
public func update()
```
- Adds tests to `MapViewControllerTest` for these changes

A future PR will:
- Add wrappers for `TGMapViewDelegate` and `TGRecognizerDelegate` as well as set an internal delegate in `MapViewController` to handle forwarding calls to the external delegates
- Transparently add back support for these excluded methods:
```
public func pickFeatureAt(screenPosition: CGPoint)
public func pickLabelAt(screenPosition: CGPoint)
public func pickMarkerAt(screenPosition: CGPoint)
```
(when a delegate is set on `MapViewController`, we can have an internal delegate handle picking features, labels, markers)
