### PR TITLE
Pass api key via commandline

### DIFF
--- a/SampleApp/AppDelegate.swift
+++ b/SampleApp/AppDelegate.swift
@@ -16,8 +16,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
-    let apiKey = Bundle.main.infoDictionary?["MAPZEN_API_KEY"] as? String
-    MapzenManager.sharedManager.apiKey = apiKey
+    let mapzenKeyName = "MAPZEN_API_KEY"
+    guard let apiKey = Bundle.main.infoDictionary?[mapzenKeyName] as? String else { return true }
+    if apiKey.isEmpty {
+      MapzenManager.sharedManager.apiKey = ProcessInfo.processInfo.environment[mapzenKeyName]
+    } else {
+      MapzenManager.sharedManager.apiKey = apiKey
+    }
     return true
   }
 

--- a/SampleApp/AppDelegate.swift
+++ b/SampleApp/AppDelegate.swift
@@ -16,7 +16,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
-    MapzenManager.sharedManager.apiKey = "[YOUR_MAPZEN_API_KEY]"
+    let apiKey = Bundle.main.infoDictionary?["MAPZEN_API_KEY"] as? String
+    MapzenManager.sharedManager.apiKey = apiKey
     return true
   }
 

--- a/SampleApp/Info.plist
+++ b/SampleApp/Info.plist
@@ -22,6 +22,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>MAPZEN_API_KEY</key>
+	<string>[YOUR_MAPZEN_API_KEY]</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Need location to make things happen!</string>
 	<key>UILaunchStoryboardName</key>

--- a/SampleApp/Info.plist
+++ b/SampleApp/Info.plist
@@ -23,7 +23,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MAPZEN_API_KEY</key>
-	<string>[YOUR_MAPZEN_API_KEY]</string>
+	<string>$(MAPZEN_API_KEY)</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Need location to make things happen!</string>
 	<key>UILaunchStoryboardName</key>

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,6 @@ checkout:
   post:
     - git submodule sync
     - git submodule update --init --recursive
-    - ./scripts/setup.sh
 
 dependencies:
   override:
@@ -24,6 +23,7 @@ test:
         -workspace ios-sdk.xcworkspace
         -scheme "ios-sdk"
         -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest'
+        MAPZEN_API_KEY=$MAPZEN_API_KEY
         clean build test |
       tee $CIRCLE_ARTIFACTS/xcode_raw.log |
       xcpretty --color --report junit --output $CIRCLE_TEST_REPORTS/xcode/results.xml

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ checkout:
   post:
     - git submodule sync
     - git submodule update --init --recursive
+    - ./scripts/setup.sh
 
 dependencies:
   override:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/libexec/PlistBuddy -c "Set :MAPZEN_API_KEY $MAPZEN_API_KEY" SampleApp/Info.plist

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-/usr/libexec/PlistBuddy -c "Set :MAPZEN_API_KEY $MAPZEN_API_KEY" SampleApp/Info.plist


### PR DESCRIPTION
- Passes api key to `xcodebuild`
- Updates key to be read from `Info.plist`
- Adds `MAPZEN_API_KEY` to circle environment variables
- Adds ability to create custom, non-shared scheme and pass api key environment variable for local development

To test this locally I added a test to `MapViewControllerTests`:
```
  func testKey() {
    let apiKey = Bundle.main.infoDictionary?["MAPZEN_API_KEY"] as? String
    XCTAssertEqual(apiKey, "theApiKey")
  }
```

and ran: 
```
xcodebuild
        -sdk iphonesimulator
        -workspace ios-sdk.xcworkspace
        -scheme "ios-sdk"
        -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest'
        MAPZEN_API_KEY=$MAPZEN_API_KEY
        clean build test
```

I also duplicated the `ios-sdk` scheme:
<img width="714" alt="screen shot 2017-03-08 at 10 18 00 am" src="https://cloud.githubusercontent.com/assets/494323/23715111/c9b6b112-03e8-11e7-8877-5ddf3355c855.png">

and added the api key as an environment variable (since I don't run xcodebuild when doing local dev):
<img width="465" alt="screen shot 2017-03-08 at 10 17 42 am" src="https://cloud.githubusercontent.com/assets/494323/23715138/dfd736e2-03e8-11e7-9271-fbc0b57fe3e1.png">


Closes #195 