### PR TITLE
Handle translucent tab bar

### DIFF
--- a/SampleApp/Base.lproj/Main.storyboard
+++ b/SampleApp/Base.lproj/Main.storyboard
@@ -19,7 +19,7 @@
                         <viewControllerLayoutGuide type="bottom" id="K0d-Qk-J2z"/>
                     </layoutGuides>
                     <glkView key="view" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" enableSetNeedsDisplay="NO" id="5Ed-Sg-6Ah">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Search..." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RdI-7G-qKE">
@@ -89,7 +89,7 @@
         <scene sceneID="y44-Ze-QWp">
             <objects>
                 <tabBarController id="T8H-gm-pBd" sceneMemberID="viewController">
-                    <tabBar key="tabBar" contentMode="scaleToFill" id="nmU-rn-abt">
+                    <tabBar key="tabBar" contentMode="scaleToFill" translucent="NO" id="nmU-rn-abt">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="49"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -113,7 +113,7 @@
                         <viewControllerLayoutGuide type="bottom" id="zRm-cR-PRf"/>
                     </layoutGuides>
                     <glkView key="view" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" enableSetNeedsDisplay="NO" id="9xq-uj-iKU">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <connections>
                             <outlet property="delegate" destination="LSW-zd-mQs" id="r8I-ur-WGk"/>
@@ -134,7 +134,7 @@
                         <viewControllerLayoutGuide type="bottom" id="Wqo-Ri-ARh"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="rqs-Ck-q5k">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Search..." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vJT-wr-8yd">
@@ -198,7 +198,7 @@
             <objects>
                 <tableViewController id="mHh-a7-7co" customClass="RoutingSearchVC" customModule="ios_sdk" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="pzB-UW-95E">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
@@ -272,7 +272,7 @@
             <objects>
                 <tableViewController id="u5O-OL-dVh" customClass="RoutingResultTableVC" customModule="ios_sdk" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="Sse-sB-OtU">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>

--- a/ios-sdkTests/MapViewControllerTests.swift
+++ b/ios-sdkTests/MapViewControllerTests.swift
@@ -595,7 +595,22 @@ class MapViewControllerTests: XCTestCase {
     controller.perform(NSSelectorFromString(selectorStr!))
     XCTAssertEqual(testApplication.urlToOpen?.absoluteString, "https://mapzen.com/rights/")
   }
-  
+
+  func testAttributionVisible() {
+    let tabVc = UITabBarController.init()
+    let vc = MapViewController.init()
+    tabVc.setViewControllers([vc], animated: false)
+    _ = vc.view
+    XCTAssertTrue(vc.attributionBtn.frame.origin.y + vc.attributionBtn.frame.size.height < tabVc.tabBar.frame.origin.y)
+  }
+
+  func testFindMeVisible() {
+    let tabVc = UITabBarController.init()
+    let vc = MapViewController.init()
+    tabVc.setViewControllers([vc], animated: false)
+    _ = vc.view
+    XCTAssertTrue(vc.findMeButton.frame.origin.y + vc.findMeButton.frame.size.height < tabVc.tabBar.frame.origin.y)
+  }
 }
 
 class TestPanDelegate : MapPanGestureDelegate {

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -360,9 +360,10 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
     return tgViewController.view as! GLKView
   }
 
-  /// The height of our enclosing tab bar controller's tab bar.
-  open var tabBarHeight : CGFloat {
-    return self.tabBarController?.tabBar.frame.height ?? 0
+  /// The height of our enclosing tab bar controller's tab bar if it is translucent.
+  open var tabBarOffset : CGFloat {
+    guard let tabBar = self.tabBarController?.tabBar else { return 0 }
+    return tabBar.isTranslucent ? tabBar.frame.height : 0
   }
 
   /**
@@ -832,12 +833,6 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
     tgViewController.mapViewDelegate = self
   }
 
-  override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-    super.viewWillTransition(to: size, with: coordinator)
-    let adjustedSize = CGSize(width: size.width, height: size.height-tabBarHeight)
-    tgViewController.viewWillTransition(to: adjustedSize, with:coordinator)
-  }
-
   //MARK: - LocationManagerDelegate
 
   open func locationDidUpdate(_ location: CLLocation) {
@@ -889,7 +884,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
     let leftConstraint = tgViewController.view.leftAnchor.constraint(equalTo: view.leftAnchor)
     let rightConstraint = tgViewController.view.rightAnchor.constraint(equalTo: view.rightAnchor)
     let topConstraint = tgViewController.view.topAnchor.constraint(equalTo: view.topAnchor)
-    let bottomConstraint = tgViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -tabBarHeight)
+    let bottomConstraint = tgViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
     NSLayoutConstraint.activate([leftConstraint, rightConstraint, topConstraint, bottomConstraint])
 
     tgViewController.didMove(toParentViewController: self)
@@ -905,8 +900,9 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
     attributionBtn.translatesAutoresizingMaskIntoConstraints = false
     mapView.addSubview(attributionBtn)
 
+    let bottomOffset = -Dimensions.defaultPadding - tabBarOffset
     let horizontalConstraint = attributionBtn.leftAnchor.constraint(equalTo: mapView.leftAnchor, constant: Dimensions.defaultPadding)
-    let verticalConstraint = attributionBtn.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -Dimensions.defaultPadding)
+    let verticalConstraint = attributionBtn.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: bottomOffset)
     NSLayoutConstraint.activate([horizontalConstraint, verticalConstraint])
   }
 
@@ -924,8 +920,9 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
     findMeButton.translatesAutoresizingMaskIntoConstraints = false
     mapView.addSubview(findMeButton)
 
+    let bottomOffset = -Dimensions.defaultPadding - tabBarOffset
     let horizontalConstraint = findMeButton.rightAnchor.constraint(equalTo: mapView.rightAnchor, constant: -Dimensions.defaultPadding)
-    let verticalConstraint = findMeButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -Dimensions.defaultPadding)
+    let verticalConstraint = findMeButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: bottomOffset)
     let widthConstraint = findMeButton.widthAnchor.constraint(equalToConstant: Dimensions.squareMapBtnSize)
     let heightConstraint = findMeButton.widthAnchor.constraint(equalToConstant: Dimensions.squareMapBtnSize)
     NSLayoutConstraint.activate([horizontalConstraint, verticalConstraint, widthConstraint, heightConstraint])


### PR DESCRIPTION
When the tab bar is translucent (the default behavior), the controller's view underlaps it. 

This PR:
- Updates find me btn and attribution constraints to consider the tab bar's offset so that they are not hidden if the bar is translucent
- Updates the sample app tab bar to not be translucent
- Removes unnecessary call to `viewWillTransition`
- Adds tests to ensure UI elements not hidden by tab bar

Closes #190 
