### PR TITLE
Annotation selector

### DIFF
--- a/ios-sdk.xcodeproj/project.pbxproj
+++ b/ios-sdk.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		7DC7F0941E70C26B009E722B /* TestLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC7F0931E70C26B009E722B /* TestLocationManager.swift */; };
 		7DC7F09A1E7204BE009E722B /* MapzenManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC7F0991E7204BE009E722B /* MapzenManagerExtensions.swift */; };
 		7DC7F09C1E72066B009E722B /* TestMapzenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC7F09B1E72066B009E722B /* TestMapzenManager.swift */; };
+		7DC7F0981E71E138009E722B /* TestAnnotationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC7F0971E71E138009E722B /* TestAnnotationTarget.swift */; };
 		7DF0AA2E1E5520ED00B0406E /* TestTGMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF0AA2D1E5520ED00B0406E /* TestTGMapViewController.swift */; };
 		AC586709D7E7D4C22AA9474D /* Pods_ios_sdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99B3EC60450343448FA4E699 /* Pods_ios_sdk.framework */; };
 		C8F52AC1BCE46BB17E1CE0A5 /* Pods_ios_sdkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A3EA87256F2EA6D0C43260A /* Pods_ios_sdkTests.framework */; };
@@ -109,6 +110,7 @@
 		7DC7F0931E70C26B009E722B /* TestLocationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLocationManager.swift; sourceTree = "<group>"; };
 		7DC7F0991E7204BE009E722B /* MapzenManagerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapzenManagerExtensions.swift; sourceTree = "<group>"; };
 		7DC7F09B1E72066B009E722B /* TestMapzenManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMapzenManager.swift; sourceTree = "<group>"; };
+		7DC7F0971E71E138009E722B /* TestAnnotationTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAnnotationTarget.swift; sourceTree = "<group>"; };
 		7DF0AA2D1E5520ED00B0406E /* TestTGMapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTGMapViewController.swift; sourceTree = "<group>"; };
 		92C35E8790FB3255237B1E77 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		99B3EC60450343448FA4E699 /* Pods_ios_sdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ios_sdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -369,6 +371,7 @@
 				7D7DAE1C1E60C5C900FFCA6F /* TestApplication.swift */,
 				7DC7F0931E70C26B009E722B /* TestLocationManager.swift */,
 				7DC7F09B1E72066B009E722B /* TestMapzenManager.swift */,
+				7DC7F0971E71E138009E722B /* TestAnnotationTarget.swift */,
 			);
 			path = "ios-sdkTests";
 			sourceTree = "<group>";
@@ -635,6 +638,7 @@
 			files = (
 				7D7DAE1D1E60C5C900FFCA6F /* TestApplication.swift in Sources */,
 				7DC7F0941E70C26B009E722B /* TestLocationManager.swift in Sources */,
+				7DC7F0981E71E138009E722B /* TestAnnotationTarget.swift in Sources */,
 				7DF0AA2E1E5520ED00B0406E /* TestTGMapViewController.swift in Sources */,
 				DB188EEC1E28492A0054DEFD /* MapzenManagerTests.swift in Sources */,
 				7DC7F09C1E72066B009E722B /* TestMapzenManager.swift in Sources */,

--- a/ios-sdkTests/MapViewControllerTests.swift
+++ b/ios-sdkTests/MapViewControllerTests.swift
@@ -388,6 +388,34 @@ class MapViewControllerTests: XCTestCase {
     XCTAssertNil(controller.currentAnnotations[testAnno2])
   }
 
+  func testAnnotationSelectorCallsSelector() {
+    let annotation = PeliasMapkitAnnotation(coordinate: CLLocationCoordinate2DMake(0.0, 0.0), title: "Title", subtitle: "Subtitle", data: nil)
+    let target = AnnotationTestTarget()
+    controller.markerSelectDelegate = target
+    annotation.setTarget(target: target, action: #selector(target.annotationClickedNoParams))
+
+    try? controller.add([annotation])
+    let markerPickResult = TGMarkerPickResult(coordinates: TGGeoPoint(), identifier: 1)
+    controller.mapView(tgViewController, didSelectMarker: markerPickResult, atScreenPosition: CGPoint())
+    XCTAssertTrue(target.annotationClickedNoParam)
+    XCTAssertFalse(target.annotationClicked)
+    XCTAssertFalse(target.markerSelected)
+  }
+
+  func testAnnotationSelectorCallsSelectorWithObject() {
+    let annotation = PeliasMapkitAnnotation(coordinate: CLLocationCoordinate2DMake(0.0, 0.0), title: "Title", subtitle: "Subtitle", data: nil)
+    let target = AnnotationTestTarget()
+    controller.markerSelectDelegate = target
+    annotation.setTarget(target: target, action: #selector(target.annotationClicked(annotation:)))
+
+    try? controller.add([annotation])
+    let markerPickResult = TGMarkerPickResult(coordinates: TGGeoPoint(), identifier: 1)
+    controller.mapView(tgViewController, didSelectMarker: markerPickResult, atScreenPosition: CGPoint())
+    XCTAssertTrue(target.annotationClicked)
+    XCTAssertFalse(target.annotationClickedNoParam)
+    XCTAssertFalse(target.markerSelected)
+  }
+
   func testPanEnabledByDefault() {
     XCTAssertTrue(controller.panEnabled)
   }

--- a/ios-sdkTests/TestAnnotationTarget.swift
+++ b/ios-sdkTests/TestAnnotationTarget.swift
@@ -1,0 +1,30 @@
+//
+//  TestAnnotationTarget.swift
+//  ios-sdk
+//
+//  Created by Sarah Lensing on 3/9/17.
+//  Copyright © 2017 Mapzen. All rights reserved.
+//
+
+import Foundation
+import TangramMap
+@testable import ios_sdk
+
+class AnnotationTestTarget : UIResponder, MapMarkerSelectDelegate {
+
+  var annotationClicked = false
+  var annotationClickedNoParam = false
+  var markerSelected = false
+
+  func annotationClicked(annotation : PeliasMapkitAnnotation) {
+    annotationClicked = true
+  }
+
+  func annotationClickedNoParams() {
+    annotationClickedNoParam = true
+  }
+
+  func mapController(_ controller: MapViewController, didSelectMarker markerPickResult: TGMarkerPickResult, atScreenPosition position: CGPoint) {
+    markerSelected = true
+  }
+}

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -207,7 +207,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
   var currentRouteMarker: TGMapMarkerId?
   open var shouldFollowCurrentLocation = false
   open var findMeButton = UIButton(type: .custom)
-  open var currentAnnotations: [PeliasMapkitAnnotation : TGMapMarkerId] = Dictionary()
+  var currentAnnotations: [PeliasMapkitAnnotation : TGMapMarkerId] = Dictionary()
   open var attributionBtn = UIButton()
 
   /// The camera type we want to use. Defaults to whatever is set in the style sheet.
@@ -989,7 +989,20 @@ extension MapViewController : TGMapViewDelegate, TGRecognizerDelegate {
   
   open func mapView(_ mapView: TGMapViewController, didSelectMarker markerPickResult: TGMarkerPickResult?, atScreenPosition position: CGPoint) {
     guard let markerPickResult = markerPickResult else { return }
-    markerSelectDelegate?.mapController(self, didSelectMarker: markerPickResult, atScreenPosition: position)
+    let markerId = markerPickResult.identifier
+    guard let annotation = currentAnnotations.keyForValue(value: markerId) else {
+      markerSelectDelegate?.mapController(self, didSelectMarker: markerPickResult, atScreenPosition: position)
+      return
+    }
+    if let target = annotation.target {
+      if let action = annotation.selector {
+        if target.canPerformAction(action, withSender: annotation) {
+          _ = target.perform(action, with: annotation)
+        } else {
+          _ = target.perform(action)
+        }
+      }
+    }
   }
   
   //MARK : TGRecognizerDelegate

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -994,13 +994,11 @@ extension MapViewController : TGMapViewDelegate, TGRecognizerDelegate {
       markerSelectDelegate?.mapController(self, didSelectMarker: markerPickResult, atScreenPosition: position)
       return
     }
-    if let target = annotation.target {
-      if let action = annotation.selector {
-        if target.canPerformAction(action, withSender: annotation) {
-          _ = target.perform(action, with: annotation)
-        } else {
-          _ = target.perform(action)
-        }
+    if let target = annotation.target, let action = annotation.selector {
+      if target.canPerformAction(action, withSender: annotation) {
+        _ = target.perform(action, with: annotation)
+      } else {
+        _ = target.perform(action)
       }
     }
   }

--- a/src/PeliasMapkitExtensions.swift
+++ b/src/PeliasMapkitExtensions.swift
@@ -70,6 +70,8 @@ open class PeliasMapkitAnnotation: NSObject, MKAnnotation {
   open let title: String?
   open let subtitle: String?
   open let data: [String: AnyObject]?
+  open var target: AnyObject?
+  open var selector: Selector?
 
   /**
    Create a fully formed `PeliasMapkitAnnotation`
@@ -86,6 +88,17 @@ open class PeliasMapkitAnnotation: NSObject, MKAnnotation {
     self.title = title
     self.subtitle = subtitle
     self.data = data
+  }
+
+  /**
+   Sets a target for the selector which will be invoked when the annotation is clicked.
+   
+   - parameter target: A target to invoke the selector on when the annotation is clicked
+   - parameter action: An selector to be invoked on the target when the annotation is clicked
+   */
+  public func setTarget(target actionTarget: AnyObject, action: Selector) {
+    target = actionTarget
+    selector = action
   }
 }
 
@@ -112,6 +125,18 @@ public extension PeliasResponse {
    This is currently the only method for producing fully formed native objects. In the future there will be additional functions and data types for this class to produce additional / more detailed objects.
   */
   public func parsedMapItems() -> [PeliasMapkitAnnotation]? {
+    return parsedMapItems(target: nil, action: nil)
+  }
+
+  /**
+   Produces an array of PeliasMapkitAnnotations based off the response from Pelias servers.
+
+   This is currently the only method for producing fully formed native objects. In the future there will be additional functions and data types for this class to produce additional / more detailed objects.
+
+   - Parameter target: An optional target to invoke the selector on when the annotations are clicked.
+   - Parameter action: An optional selector to be invoked when the created annotations are clicked.
+   */
+  public func parsedMapItems(target: AnyObject?, action: Selector?) -> [PeliasMapkitAnnotation]? {
     //TODO: This should get refactored into eventually being a real GeoJSON decoder, and split out the MapItem creation
     var mapItems = [PeliasMapkitAnnotation]()
     if let jsonDictionary = parsedResponse?.parsedResponse {
@@ -131,6 +156,11 @@ public extension PeliasResponse {
         //MKPlacemark
         let name = featureProperties["label"] as? String
         let mapAnnotation = PeliasMapkitAnnotation(coordinate: coordinate, title: name, subtitle: nil, data: addressDictionary as [String : AnyObject]?)
+        if let target = target {
+          if let action = action {
+            mapAnnotation.setTarget(target: target, action: action)
+          }
+        }
 
         mapItems.append(mapAnnotation)
       }

--- a/src/PeliasMapkitExtensions.swift
+++ b/src/PeliasMapkitExtensions.swift
@@ -70,7 +70,7 @@ open class PeliasMapkitAnnotation: NSObject, MKAnnotation {
   open let title: String?
   open let subtitle: String?
   open let data: [String: AnyObject]?
-  open var target: AnyObject?
+  open var target: UIResponder?
   open var selector: Selector?
 
   /**
@@ -96,7 +96,7 @@ open class PeliasMapkitAnnotation: NSObject, MKAnnotation {
    - parameter target: A target to invoke the selector on when the annotation is clicked
    - parameter action: An selector to be invoked on the target when the annotation is clicked
    */
-  public func setTarget(target actionTarget: AnyObject, action: Selector) {
+  public func setTarget(target actionTarget: UIResponder, action: Selector) {
     target = actionTarget
     selector = action
   }
@@ -136,7 +136,7 @@ public extension PeliasResponse {
    - Parameter target: An optional target to invoke the selector on when the annotations are clicked.
    - Parameter action: An optional selector to be invoked when the created annotations are clicked.
    */
-  public func parsedMapItems(target: AnyObject?, action: Selector?) -> [PeliasMapkitAnnotation]? {
+  public func parsedMapItems(target: UIResponder?, action: Selector?) -> [PeliasMapkitAnnotation]? {
     //TODO: This should get refactored into eventually being a real GeoJSON decoder, and split out the MapItem creation
     var mapItems = [PeliasMapkitAnnotation]()
     if let jsonDictionary = parsedResponse?.parsedResponse {

--- a/src/PeliasMapkitExtensions.swift
+++ b/src/PeliasMapkitExtensions.swift
@@ -156,10 +156,8 @@ public extension PeliasResponse {
         //MKPlacemark
         let name = featureProperties["label"] as? String
         let mapAnnotation = PeliasMapkitAnnotation(coordinate: coordinate, title: name, subtitle: nil, data: addressDictionary as [String : AnyObject]?)
-        if let target = target {
-          if let action = action {
-            mapAnnotation.setTarget(target: target, action: action)
-          }
+        if let target = target, let action = action {
+          mapAnnotation.setTarget(target: target, action: action)
         }
 
         mapItems.append(mapAnnotation)


### PR DESCRIPTION
- Updates `PeliasMapkitAnnotation` to allow setting a target and action to be invoked when annotation is clicked
- Annotation selectors can have a `PeliasMapkitAnnotation` parameter or no parameters
- Updates `MapViewController` to filter out calls to `MapSelectDelegate` for  `PeliasMapkitAnnotation` objects
- Internalizes `currentAnnotations` map in `MapViewController`
- Updates search pins example to use selectors
- Adds tests for new functionality

Closes #180 