### PR TITLE
Create api-docs.md

### DIFF
--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -1,0 +1,5 @@
+# API Docs
+
+Browse the Mapzen iOS SDK API docs generated using [Jazzy](https://github.com/realm/jazzy).
+
+### [Browse Documentation](http://mapzen.github.io/ios/)

--- a/release_checklist.md
+++ b/release_checklist.md
@@ -10,5 +10,6 @@
 2. Update the Mapzen-ios-sdk.podspec version number property with that same tag
 3. Update the .swift file with the current version of swift the sdk is compiled against
 4. Run `pod spec lint` to make sure everything is happy. Fix issues if not happy (eventually we should document known possible issues). Submit to PR once lint is clean.
-3. Once #2 PR merges, push the updated pod spec to trunk: `pod trunk push Mapzen-ios-sdk.podspec`
-4. Write up release notes and release the SDK on github.
+5. Once #2 PR merges, push the updated pod spec to trunk: `pod trunk push Mapzen-ios-sdk.podspec`
+6. Write up release notes and release the SDK on github.
+7. Re-generate API docs using Jazzy and push changes to `gh-pages` branch to update http://mapzen.github.io/ios/.


### PR DESCRIPTION
### Overview

Link to Jazzy code docs hosted on Github Pages

### Proposed Changes

Adds api-docs.md with link to documentation hosted on http://mapzen.github.io/ios/