### PR TITLE
Update podfile to 0.5.1 release commit and use stylingString

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ use_frameworks!
 def shared_pods
   pod 'Pelias', '~> 1.0.0-beta'
   pod 'OnTheRoad', :git => 'https://github.com/mapzen/on-the-road_ios.git', :commit => '603fe7a'
-  pod 'Tangram-es', :git => 'https://github.com/tangrams/ios-framework.git', :branch => 'master', :commit => 'a1b1338'
+  pod 'Tangram-es', '~> 0.5.1'
 end
 
 target "ios-sdk" do

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ use_frameworks!
 def shared_pods
   pod 'Pelias', '~> 1.0.0-beta'
   pod 'OnTheRoad', :git => 'https://github.com/mapzen/on-the-road_ios.git', :commit => '603fe7a'
-  pod 'Tangram-es', :git => 'https://github.com/tangrams/ios-framework.git', :branch => 'universal-0.5.1-preview' 
+  pod 'Tangram-es', :git => 'https://github.com/tangrams/ios-framework.git', :branch => 'master', :commit => 'a1b1338'
 end
 
 target "ios-sdk" do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,30 +8,23 @@ PODS:
 DEPENDENCIES:
   - OnTheRoad (from `https://github.com/mapzen/on-the-road_ios.git`, commit `603fe7a`)
   - Pelias (~> 1.0.0-beta)
-  - Tangram-es (from `https://github.com/tangrams/ios-framework.git`, commit `a1b1338`, branch `master`)
+  - Tangram-es (~> 0.5.1)
 
 EXTERNAL SOURCES:
   OnTheRoad:
     :commit: 603fe7a
     :git: https://github.com/mapzen/on-the-road_ios.git
-  Tangram-es:
-    :branch: master
-    :commit: a1b1338
-    :git: https://github.com/tangrams/ios-framework.git
 
 CHECKOUT OPTIONS:
   OnTheRoad:
     :commit: 603fe7a
     :git: https://github.com/mapzen/on-the-road_ios.git
-  Tangram-es:
-    :commit: a1b1338b9f65a77e2b96b0d3661722660a6cdb0c
-    :git: https://github.com/tangrams/ios-framework.git
 
 SPEC CHECKSUMS:
   OnTheRoad: d8027a9d9c5e4c3ec885ada373aa20d28fdcbe1b
   Pelias: 6bcff7e153cdad93faf07028b6eb124636afdfc7
   Tangram-es: 5c558140e072edf59d113fa9d0580c61440a530b
 
-PODFILE CHECKSUM: a236f04eed3ed2a71e94af36f9d22cb08387aa19
+PODFILE CHECKSUM: 16f415eda2ff190a394c5a50e428dbe861ab6258
 
 COCOAPODS: 1.2.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,19 +3,20 @@ PODS:
   - Pelias (1.0.0-beta4):
     - Pelias/Core (= 1.0.0-beta4)
   - Pelias/Core (1.0.0-beta4)
-  - Tangram-es (0.5.0)
+  - Tangram-es (0.5.1)
 
 DEPENDENCIES:
   - OnTheRoad (from `https://github.com/mapzen/on-the-road_ios.git`, commit `603fe7a`)
   - Pelias (~> 1.0.0-beta)
-  - Tangram-es (from `https://github.com/tangrams/ios-framework.git`, branch `universal-0.5.1-preview`)
+  - Tangram-es (from `https://github.com/tangrams/ios-framework.git`, commit `a1b1338`, branch `master`)
 
 EXTERNAL SOURCES:
   OnTheRoad:
     :commit: 603fe7a
     :git: https://github.com/mapzen/on-the-road_ios.git
   Tangram-es:
-    :branch: universal-0.5.1-preview
+    :branch: master
+    :commit: a1b1338
     :git: https://github.com/tangrams/ios-framework.git
 
 CHECKOUT OPTIONS:
@@ -23,14 +24,14 @@ CHECKOUT OPTIONS:
     :commit: 603fe7a
     :git: https://github.com/mapzen/on-the-road_ios.git
   Tangram-es:
-    :commit: 6b59e0b8eb601cf63cf6abbbbfe1f3136cfc9d3c
+    :commit: a1b1338b9f65a77e2b96b0d3661722660a6cdb0c
     :git: https://github.com/tangrams/ios-framework.git
 
 SPEC CHECKSUMS:
   OnTheRoad: d8027a9d9c5e4c3ec885ada373aa20d28fdcbe1b
   Pelias: 6bcff7e153cdad93faf07028b6eb124636afdfc7
-  Tangram-es: ee322f2d6f4d9bbf47815bcb9fe5799758db6d8f
+  Tangram-es: 5c558140e072edf59d113fa9d0580c61440a530b
 
-PODFILE CHECKSUM: ba15f2ed7d5e274ecf00decf412c502dba6c5462
+PODFILE CHECKSUM: a236f04eed3ed2a71e94af36f9d22cb08387aa19
 
 COCOAPODS: 1.2.0

--- a/SampleApp/TangramVC.swift
+++ b/SampleApp/TangramVC.swift
@@ -15,7 +15,7 @@ class TangramVC:  SampleMapViewController, MapMarkerSelectDelegate {
 
   lazy var testMarker : TGMarker = { [unowned self] in
     let marker = TGMarker.init(mapView: self.tgViewController)
-    marker.styling = "{ style: 'points', color: 'white', size: [50px, 50px], collide: false, interactive: true }"
+    marker.stylingString = "{ style: 'points', color: 'white', size: [50px, 50px], collide: false, interactive: true }"
     if let logo = UIImage(named: "mapzen_logo") {
       marker.icon = logo
     }

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -668,7 +668,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
       let marker = TGMarker.init(mapView: tgViewController)
       currentLocationGem = marker;
       locationManager.requestWhenInUseAuthorization()
-      marker.styling = "{ style: ux-location-gem-overlay, sprite: ux-current-location, size: 36px, collide: false }"
+      marker.stylingString = "{ style: ux-location-gem-overlay, sprite: ux-current-location, size: 36px, collide: false }"
       //Set visibility to false since we have to wait until we have an accurate location
       marker.visible = false
       return true
@@ -708,7 +708,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
 //                      userInfo: nil)
 //      }
       newMarker.point = TGGeoPoint(coordinate: annotation.coordinate)
-      newMarker.styling = "{ style: sdk-point-overlay, sprite: ux-search-active, size: [24, 36px], collide: false, interactive: true }"
+      newMarker.stylingString = "{ style: sdk-point-overlay, sprite: ux-search-active, size: [24, 36px], collide: false, interactive: true }"
       currentAnnotations[annotation] = newMarker
     }
   }
@@ -773,7 +773,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
       polyLine.add(TGGeoPoint(coordinate: point!))
     }
     let marker = TGMarker.init(mapView: tgViewController)
-    marker.styling = "{ style: ux-route-line-overlay, color: '#06a6d4',  width: [[0,3.5px],[5,5px],[9,7px],[10,6px],[11,6px],[13,8px],[14,9px],[15,10px],[16,11px],[17,12px],[18,10px]], order: 500 }"
+    marker.stylingString = "{ style: ux-route-line-overlay, color: '#06a6d4',  width: [[0,3.5px],[5,5px],[9,7px],[10,6px],[11,6px],[13,8px],[14,9px],[15,10px],[16,11px],[17,12px],[18,10px]], order: 500 }"
     marker.polyline = polyLine
     currentRouteMarker = marker
   }


### PR DESCRIPTION
### Overview
Fixes build errors caused by outdated tangram dependency

### Proposed Changes
Updates the tangram dependency to point to the 0.5.1 release ~~commit~~ and migrates sdk to use renamed `stylingString` property

Closes #227 
Closes #229 