### PR TITLE
Adds low memory management to MapViewController and fixes some other bugs

### DIFF
--- a/ios-sdkTests/MapViewControllerTests.swift
+++ b/ios-sdkTests/MapViewControllerTests.swift
@@ -683,7 +683,10 @@ class MapViewControllerTests: XCTestCase {
     controller.cameraType = .flat
     controller.zoom = 3.0
     controller.currentStyle = .cinnabar
-    
+    _ = controller.showCurrentLocation(true)
+    controller.findMeButton.isHidden = false
+    controller.shouldFollowCurrentLocation = true
+
     // Normally the OS would call these but can't replicate that easily in tests
     controller.didReceiveMemoryWarning()
 
@@ -698,6 +701,9 @@ class MapViewControllerTests: XCTestCase {
     XCTAssertEqual(controller.cameraType, .flat)
     XCTAssertEqualWithAccuracy(controller.zoom, 3.0, accuracy: FLT_EPSILON)
     XCTAssertEqual(controller.currentStyle, .cinnabar)
+    XCTAssertTrue(controller.shouldShowCurrentLocation)
+    XCTAssertFalse(controller.findMeButton.isHidden)
+    XCTAssertTrue(controller.findMeButton.isSelected) // Determined by shouldFollowCurrentLocation
   }
 }
 

--- a/ios-sdkTests/MapViewControllerTests.swift
+++ b/ios-sdkTests/MapViewControllerTests.swift
@@ -685,6 +685,7 @@ class MapViewControllerTests: XCTestCase {
     controller.currentStyle = .cinnabar
     _ = controller.showCurrentLocation(true)
     controller.findMeButton.isHidden = false
+    controller.findMeButton.isEnabled = true
     controller.shouldFollowCurrentLocation = true
 
     // Normally the OS would call these but can't replicate that easily in tests
@@ -704,6 +705,7 @@ class MapViewControllerTests: XCTestCase {
     XCTAssertTrue(controller.shouldShowCurrentLocation)
     XCTAssertFalse(controller.findMeButton.isHidden)
     XCTAssertTrue(controller.findMeButton.isSelected) // Determined by shouldFollowCurrentLocation
+    XCTAssertTrue(controller.findMeButton.isEnabled)
   }
 }
 

--- a/ios-sdkTests/MapViewControllerTests.swift
+++ b/ios-sdkTests/MapViewControllerTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import ios_sdk
 import TangramMap
+import OnTheRoad
 import CoreLocation
 
 class TestMapViewController: MapViewController {
@@ -122,26 +123,31 @@ class MapViewControllerTests: XCTestCase {
   func testLoadBubbleWrap() {
     try? controller.loadStyle(.bubbleWrap)
     XCTAssertEqual(tgViewController.scenePath, "bubble-wrap-style-more-labels.yaml")
+    XCTAssertEqual(controller.currentStyle, .bubbleWrap)
   }
 
   func testLoadCinnabar() {
     try? controller.loadStyle(.cinnabar)
     XCTAssertEqual(tgViewController.scenePath, "cinnabar-style-more-labels.yaml")
+    XCTAssertEqual(controller.currentStyle, .cinnabar)
   }
 
   func testLoadRefill() {
     try? controller.loadStyle(.refill)
     XCTAssertEqual(tgViewController.scenePath, "refill-style-more-labels.yaml")
+    XCTAssertEqual(controller.currentStyle, .refill)
   }
 
   func testLoadWalkabout() {
     try? controller.loadStyle(.walkabout)
     XCTAssertEqual(tgViewController.scenePath, "walkabout-style-more-labels.yaml")
+    XCTAssertEqual(controller.currentStyle, .walkabout)
   }
 
   func testLoadZinc() {
     try? controller.loadStyle(.zinc)
     XCTAssertEqual(tgViewController.scenePath, "zinc-style-more-labels.yaml")
+    XCTAssertEqual(controller.currentStyle, .zinc)
   }
   
   func testLoadStyleWithUpdates() {
@@ -239,6 +245,33 @@ class MapViewControllerTests: XCTestCase {
     XCTAssertTrue(tgViewController.appliedSceneUpdates)
   }
 
+  func testTiltProperty() {
+    controller.tilt = 1.0
+    XCTAssertEqual(controller.tilt, 1.0)
+  }
+
+  func testRotationProperty() {
+    controller.rotation = 1.0
+    XCTAssertEqual(controller.rotation, 1.0)
+  }
+
+  func testZoomProperty() {
+    controller.zoom = 1.0
+    XCTAssertEqual(controller.zoom, 1.0)
+  }
+
+  func testCameraTypeProperty() {
+    controller.cameraType = .flat
+    XCTAssertEqual(controller.cameraType, .flat)
+  }
+
+  func testPositionProperty() {
+    let point = TGGeoPointMake(1.0, 2.0)
+    controller.position = point
+    //We don't check latitude because of an underlying precision issue with Tangram. More investigation needed.
+    XCTAssertEqualWithAccuracy(controller.position.longitude, point.longitude, accuracy: DBL_EPSILON)
+  }
+
   func testLngLatToScreenPosition() {
     let point = TGGeoPointMake(70.0, 40.0)
     let _ = controller.lngLat(toScreenPosition: point)
@@ -323,7 +356,6 @@ class MapViewControllerTests: XCTestCase {
     XCTAssertTrue(controller.currentLocationGemValue() != nil)
   }
 
-  //MARK: - LocationManagerDelegate Tests
   func testLocationUpdateSansMarkerGeneration() {
     //Setup
     controller.locationDidUpdate(mockLocation)
@@ -642,6 +674,30 @@ class MapViewControllerTests: XCTestCase {
     tabVc.setViewControllers([vc], animated: false)
     _ = vc.view
     XCTAssertTrue(vc.findMeButton.frame.origin.y + vc.findMeButton.frame.size.height < tabVc.tabBar.frame.origin.y)
+  }
+
+  func testMemoryWarning() {
+    controller.tilt = 1.0
+    controller.rotation = 2.0
+    controller.position = TGGeoPointMake(1.0, 2.0)
+    controller.cameraType = .flat
+    controller.zoom = 3.0
+    controller.currentStyle = .cinnabar
+    
+    // Normally the OS would call these but can't replicate that easily in tests
+    controller.didReceiveMemoryWarning()
+
+    XCTAssertNotNil(controller.stateSaver)
+    controller.reloadTGViewController()
+    controller.recreateMap(controller.stateSaver!)
+
+    XCTAssertEqualWithAccuracy(controller.tilt, 1.0, accuracy: FLT_EPSILON)
+    XCTAssertEqualWithAccuracy(controller.rotation, 2.0, accuracy: FLT_EPSILON)
+    //We don't check latitude because of a weird underlying issue with Tangram rounding errors on it. Further investigation required
+    XCTAssertEqualWithAccuracy(controller.position.longitude, 1.0, accuracy: DBL_EPSILON)
+    XCTAssertEqual(controller.cameraType, .flat)
+    XCTAssertEqualWithAccuracy(controller.zoom, 3.0, accuracy: FLT_EPSILON)
+    XCTAssertEqual(controller.currentStyle, .cinnabar)
   }
 }
 

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -870,6 +870,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
 
     // Location Marker reset
     if shouldShowCurrentLocation {
+      currentLocationGem?.map = tgViewController
       _ = self.showCurrentLocation(true)
     }
 
@@ -879,6 +880,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
     self.setupFindMeButton()
     findMeButton.isHidden = originalButton.isHidden
     findMeButton.isSelected = shouldFollowCurrentLocation
+    findMeButton.isEnabled = originalButton.isEnabled
   }
 
   // MARK:- ViewController Lifecycle
@@ -923,6 +925,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
       //Probably unnecessary, but just incase we don't want any calls coming through from older versions that the OS has yet to clean up
       tgViewController.gestureDelegate = nil
       tgViewController.mapViewDelegate = nil
+      currentLocationGem?.map = nil
       tgViewController = TGMapViewController()
     }
     super.didReceiveMemoryWarning()

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -13,6 +13,15 @@ import CoreLocation
 import Pelias
 import OnTheRoad
 
+struct StateReclaimer {
+  public let tilt: Float
+  public let rotation: Float
+  public let zoom: Float
+  public let position: TGGeoPoint
+  public let cameraType: TGCameraType
+  public let mapStyle: MapStyle
+}
+
 /** 
   Mapzen Error Enumeration
   - generalError: The general case for things we're not quite sure what happened.
@@ -201,6 +210,8 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
   private static let mapzenRights = "https://mapzen.com/rights/"
   private static let kGlobalPathApiKey = "global.sdk_mapzen_api_key"
   private static let kGlobalPathLanguage = "global.ux_language"
+  private let kDefaultSearchPinStyle = "{ style: sdk-point-overlay, sprite: ux-search-active, size: [24, 36px], collide: false, interactive: true }"
+  private var isCurrentlyVisible = false // We can't rely on things like window being non-nil because page controllers have a non-nil window as they're being rendered off screen
 
   let application : ApplicationProtocol
   open var tgViewController: TGMapViewController = TGMapViewController()
@@ -208,16 +219,19 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
   var lastSetPoint: TGGeoPoint?
   var shouldShowCurrentLocation = false
   var currentRouteMarker: TGMarker?
+  var currentRoute: OTRRoutingResult?
   open var shouldFollowCurrentLocation = false
   open var findMeButton = UIButton(type: .custom)
   var currentAnnotations: [PeliasMapkitAnnotation : TGMarker] = Dictionary()
   open var attributionBtn = UIButton()
   private var locale = Locale.current
+  var stateSaver: StateReclaimer?
+  var currentStyle: MapStyle = .bubbleWrap
 
   /// The camera type we want to use. Defaults to whatever is set in the style sheet.
   open var cameraType: TGCameraType {
     set {
-      tgViewController.cameraType = cameraType
+      tgViewController.cameraType = newValue
     }
     get {
       return tgViewController.cameraType
@@ -227,7 +241,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
   /// The current position of the map in longitude / latitude.
   open var position: TGGeoPoint {
     set {
-      tgViewController.position = position
+      tgViewController.position = newValue
     }
     get {
       return tgViewController.position
@@ -237,7 +251,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
   /// The current zoom level.
   open var zoom: Float {
     set {
-      tgViewController.zoom = zoom
+      tgViewController.zoom = newValue
     }
     get {
       return tgViewController.zoom
@@ -247,7 +261,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
   /// The current rotation, in radians from north.
   open var rotation: Float {
     set {
-      tgViewController.rotation = rotation
+      tgViewController.rotation = newValue
     }
     get {
       return tgViewController.rotation
@@ -257,7 +271,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
   /// The current tilt in radians.
   open var tilt: Float {
     set {
-      tgViewController.tilt = tilt
+      tgViewController.tilt = newValue
     }
     get {
       return tgViewController.tilt
@@ -515,6 +529,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
   open func loadStyle(_ style: MapStyle, locale l: Locale, sceneUpdates: [TGSceneUpdate]) throws {
     locale = l
     guard let sceneFile = styles.keyForValue(value: style) else { return }
+    currentStyle = style
     try tgViewController.loadSceneFile(sceneFile, sceneUpdates: allSceneUpdates(sceneUpdates))
   }
 
@@ -552,6 +567,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
   open func loadStyleAsync(_ style: MapStyle, sceneUpdates: [TGSceneUpdate], onStyleLoaded: OnStyleLoaded?) throws {
     onStyleLoadedClosure = onStyleLoaded
     guard let sceneFile = styles.keyForValue(value: style) else { return }
+    currentStyle = style
     try tgViewController.loadSceneFileAsync(sceneFile, sceneUpdates: allSceneUpdates(sceneUpdates))
   }
 
@@ -568,6 +584,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
     locale = l
     onStyleLoadedClosure = onStyleLoaded
     guard let sceneFile = styles.keyForValue(value: style) else { return }
+    currentStyle = style
     try tgViewController.loadSceneFileAsync(sceneFile, sceneUpdates: allSceneUpdates(sceneUpdates))
   }
 
@@ -709,7 +726,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
 //                      userInfo: nil)
 //      }
       newMarker.point = TGGeoPoint(coordinate: annotation.coordinate)
-      newMarker.stylingString = "{ style: sdk-point-overlay, sprite: ux-search-active, size: [24, 36px], collide: false, interactive: true }"
+      newMarker.stylingString = kDefaultSearchPinStyle
       currentAnnotations[annotation] = newMarker
     }
   }
@@ -761,6 +778,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
     if let routeMarker = currentRouteMarker {
       //We don't throw if the remove fails here because we want to silently replace the route
       currentRouteMarker = nil
+      currentRoute = nil
       //TODO: handle marker remove error?
       routeMarker.map = nil
     }
@@ -777,6 +795,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
     marker.stylingString = "{ style: ux-route-line-overlay, color: '#06a6d4',  width: [[0,3.5px],[5,5px],[9,7px],[10,6px],[11,6px],[13,8px],[14,9px],[15,10px],[16,11px],[17,12px],[18,10px]], order: 500 }"
     marker.polyline = polyLine
     currentRouteMarker = marker
+    currentRoute = route
   }
 
   /**
@@ -794,6 +813,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
 
     currentRouteMarker.map = nil
     self.currentRouteMarker = nil
+    currentRoute = nil
   }
 
   @objc func defaultFindMeAction(_ button: UIButton, touchEvent: UIEvent) {
@@ -802,16 +822,92 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
     shouldFollowCurrentLocation = button.isSelected
   }
 
+  // MARK:- ViewController Lifecycle
+
   override open func viewDidLoad() {
     super.viewDidLoad()
     locationManager.delegate = self
-
     setupTgControllerView()
     setupAttribution()
     setupFindMeButton()
 
     tgViewController.gestureDelegate = self
     tgViewController.mapViewDelegate = self
+  }
+
+  func reloadTGViewController() {
+    guard let unwrappedSaver = stateSaver else { return }
+    setupTgControllerView()
+    tgViewController.gestureDelegate = self
+    tgViewController.mapViewDelegate = self
+    do {
+      try loadStyleAsync(unwrappedSaver.mapStyle) { [unowned self] (styleLoaded) in
+        self.recreateMap(unwrappedSaver)
+        self.stateSaver = nil
+      }
+    } catch {
+      // In the event Tangram can't do the reload, we're pretty much dead in the water.
+      return
+    }
+  }
+
+  func recreateMap(_ state: StateReclaimer) {
+    let oldAnnotations = self.currentAnnotations
+    self.currentAnnotations = Dictionary()
+    for (annotation, marker) in oldAnnotations {
+      let newMarker = TGMarker.init(mapView: self.tgViewController)
+      newMarker.point = marker.point
+      newMarker.stylingString = marker.stylingString
+      self.currentAnnotations[annotation] = newMarker
+    }
+    if let currentRoute = self.currentRoute {
+      do {
+        try self.display(currentRoute)
+      } catch {
+        //Silently catch this - we may still be able to recover from here sans route
+      }
+    }
+    self.tilt = state.tilt
+    self.rotation = state.rotation
+    self.zoom = state.zoom
+    self.position = state.position
+    self.cameraType = state.cameraType
+    self.setupAttribution()
+    self.setupFindMeButton()
+  }
+
+  override open func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    //We only want to attempt to reload incase we reloaded due to memory issues
+    if (!tgViewController.isViewLoaded) {
+      print("reloading tgviewcontroller due to memory warning removal")
+      reloadTGViewController()
+    }
+  }
+
+  override open func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    isCurrentlyVisible = true
+  }
+
+  override open func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    isCurrentlyVisible = false
+  }
+
+  override open func didReceiveMemoryWarning() {
+    if (!isCurrentlyVisible) {
+      tgViewController.willMove(toParentViewController: nil)
+      tgViewController.view.removeConstraints(tgViewController.view.constraints)
+      tgViewController.view.removeFromSuperview()
+      tgViewController.removeFromParentViewController()
+      stateSaver = StateReclaimer(tilt: tilt, rotation: rotation, zoom: zoom, position: position, cameraType: cameraType, mapStyle: currentStyle)
+      //Probably unnecessary, but just incase we don't want any calls coming through from older versions that the OS has yet to clean up
+      tgViewController.gestureDelegate = nil
+      tgViewController.mapViewDelegate = nil
+      tgViewController = TGMapViewController()
+    }
+    super.didReceiveMemoryWarning()
   }
 
   //MARK: - LocationManagerDelegate


### PR DESCRIPTION
### Overview
MapViewController now tries to recover from a low memory warning.
There were also some issues with properties not behaving as expected
that were fixed as part of this.

### Proposed Changes
Implement a management layer for low memory situations so we can save state and then attempt to rebuild the state when coming back on screen. Tested on an iPhone 6S+ it seems to behave well, but could use more testing on older / slower devices.

Fixes #235 
Fixes #222