### PR TITLE
Add Marker Class

### DIFF
--- a/SampleApp/DemoMapViewController.swift
+++ b/SampleApp/DemoMapViewController.swift
@@ -38,7 +38,7 @@ class DemoMapViewController:  SampleMapViewController, MapMarkerSelectDelegate {
   }
   
   //MARK : MapSelectDelegate  
-  func mapController(_ controller: MapViewController, didSelectMarker markerPickResult: TGMarkerPickResult, atScreenPosition position: CGPoint) {
+  func mapController(_ controller: MapViewController, didSelectMarker marker: Marker, atScreenPosition position: CGPoint) {
     let alert = UIAlertController(title: "Marker Selected", message: nil, preferredStyle: .alert)
     alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
     present(alert, animated: true, completion: nil)

--- a/SampleApp/DemoMapViewController.swift
+++ b/SampleApp/DemoMapViewController.swift
@@ -38,7 +38,7 @@ class DemoMapViewController:  SampleMapViewController, MapMarkerSelectDelegate {
   }
   
   //MARK : MapSelectDelegate  
-  func mapController(_ controller: MapViewController, didSelectMarker marker: Marker, atScreenPosition position: CGPoint) {
+  func mapController(_ controller: MapViewController, didSelectMarker marker: GenericMarker, atScreenPosition position: CGPoint) {
     let alert = UIAlertController(title: "Marker Selected", message: nil, preferredStyle: .alert)
     alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
     present(alert, animated: true, completion: nil)

--- a/SampleApp/DemoMapViewController.swift
+++ b/SampleApp/DemoMapViewController.swift
@@ -11,7 +11,6 @@ import TangramMap
 class DemoMapViewController:  SampleMapViewController, MapMarkerSelectDelegate {
 
   private var styleLoaded = false
-  private var markerVisible = false
 
   lazy var activityIndicator : UIActivityIndicatorView = {
     let indicator = UIActivityIndicatorView.init(activityIndicatorStyle: .whiteLarge)

--- a/ios-sdk.xcodeproj/project.pbxproj
+++ b/ios-sdk.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7D503BCC1E77457A00FDDC4F /* SampleMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D503BCB1E77457A00FDDC4F /* SampleMapViewController.swift */; };
 		7D503BCE1E77468B00FDDC4F /* SampleTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D503BCD1E77468B00FDDC4F /* SampleTableViewController.swift */; };
 		7D503BD01E78944300FDDC4F /* TestTGMarkerPickResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D503BCF1E78944300FDDC4F /* TestTGMarkerPickResult.swift */; };
+		7D5616D51E89706700D95E5D /* RoutingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5616D41E89706700D95E5D /* RoutingControllerTests.swift */; };
 		7D7847251E6775EA000D56CA /* Dimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7847241E6775EA000D56CA /* Dimensions.swift */; };
 		7D7D49931E7708E5006074EB /* TestSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7D49921E7708E5006074EB /* TestSessionDataTask.swift */; };
 		7D7D49951E7709A1006074EB /* TestUrlSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7D49941E7709A1006074EB /* TestUrlSession.swift */; };
@@ -34,11 +35,13 @@
 		7DB181531E81B73A001F9B49 /* SearchDataConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DB181521E81B73A001F9B49 /* SearchDataConverterTests.swift */; };
 		7DB181551E81B745001F9B49 /* SearchDataObjectsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DB181541E81B745001F9B49 /* SearchDataObjectsTests.swift */; };
 		7DB181571E81B77B001F9B49 /* SearchResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DB181561E81B77B001F9B49 /* SearchResponseTests.swift */; };
+		7DB181591E831414001F9B49 /* Marker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DB181581E831414001F9B49 /* Marker.swift */; };
 		7DC7F0941E70C26B009E722B /* TestLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC7F0931E70C26B009E722B /* TestLocationManager.swift */; };
 		7DC7F0981E71E138009E722B /* TestAnnotationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC7F0971E71E138009E722B /* TestAnnotationTarget.swift */; };
 		7DC7F09A1E7204BE009E722B /* MapzenManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC7F0991E7204BE009E722B /* MapzenManagerExtensions.swift */; };
 		7DC7F09C1E72066B009E722B /* TestMapzenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC7F09B1E72066B009E722B /* TestMapzenManager.swift */; };
-		7DC7F0A21E770443009E722B /* RoutingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC7F0A11E770443009E722B /* RoutingControllerTests.swift */; };
+		7DDF87551E832F38001B01A8 /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DDF87541E832F38001B01A8 /* UIColorExtensions.swift */; };
+		7DDF87591E8368F8001B01A8 /* MarkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DDF87581E8368F8001B01A8 /* MarkerTests.swift */; };
 		7DF0AA2E1E5520ED00B0406E /* TestTGMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF0AA2D1E5520ED00B0406E /* TestTGMapViewController.swift */; };
 		AC586709D7E7D4C22AA9474D /* Pods_ios_sdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99B3EC60450343448FA4E699 /* Pods_ios_sdk.framework */; };
 		C8F52AC1BCE46BB17E1CE0A5 /* Pods_ios_sdkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A3EA87256F2EA6D0C43260A /* Pods_ios_sdkTests.framework */; };
@@ -107,6 +110,7 @@
 		7D503BCB1E77457A00FDDC4F /* SampleMapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleMapViewController.swift; sourceTree = "<group>"; };
 		7D503BCD1E77468B00FDDC4F /* SampleTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleTableViewController.swift; sourceTree = "<group>"; };
 		7D503BCF1E78944300FDDC4F /* TestTGMarkerPickResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTGMarkerPickResult.swift; sourceTree = "<group>"; };
+		7D5616D41E89706700D95E5D /* RoutingControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoutingControllerTests.swift; sourceTree = "<group>"; };
 		7D7847241E6775EA000D56CA /* Dimensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dimensions.swift; sourceTree = "<group>"; };
 		7D7D49921E7708E5006074EB /* TestSessionDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSessionDataTask.swift; sourceTree = "<group>"; };
 		7D7D49941E7709A1006074EB /* TestUrlSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUrlSession.swift; sourceTree = "<group>"; };
@@ -134,11 +138,13 @@
 		7DB181521E81B73A001F9B49 /* SearchDataConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchDataConverterTests.swift; sourceTree = "<group>"; };
 		7DB181541E81B745001F9B49 /* SearchDataObjectsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchDataObjectsTests.swift; sourceTree = "<group>"; };
 		7DB181561E81B77B001F9B49 /* SearchResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchResponseTests.swift; sourceTree = "<group>"; };
+		7DB181581E831414001F9B49 /* Marker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Marker.swift; sourceTree = "<group>"; };
 		7DC7F0931E70C26B009E722B /* TestLocationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLocationManager.swift; sourceTree = "<group>"; };
 		7DC7F0971E71E138009E722B /* TestAnnotationTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAnnotationTarget.swift; sourceTree = "<group>"; };
 		7DC7F0991E7204BE009E722B /* MapzenManagerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapzenManagerExtensions.swift; sourceTree = "<group>"; };
 		7DC7F09B1E72066B009E722B /* TestMapzenManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMapzenManager.swift; sourceTree = "<group>"; };
-		7DC7F0A11E770443009E722B /* RoutingControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoutingControllerTests.swift; sourceTree = "<group>"; };
+		7DDF87541E832F38001B01A8 /* UIColorExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtensions.swift; sourceTree = "<group>"; };
+		7DDF87581E8368F8001B01A8 /* MarkerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkerTests.swift; sourceTree = "<group>"; };
 		7DF0AA2D1E5520ED00B0406E /* TestTGMapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTGMapViewController.swift; sourceTree = "<group>"; };
 		92C35E8790FB3255237B1E77 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		99B3EC60450343448FA4E699 /* Pods_ios_sdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ios_sdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -393,6 +399,7 @@
 		DB7A33EB1C8F8E8B009CC743 /* ios-sdkTests */ = {
 			isa = PBXGroup;
 			children = (
+				7D5616D41E89706700D95E5D /* RoutingControllerTests.swift */,
 				DB7A33EE1C8F8E8B009CC743 /* Info.plist */,
 				DBCBC5BE1E0AE1CF0045B345 /* MapViewControllerTests.swift */,
 				DB188EEB1E28492A0054DEFD /* MapzenManagerTests.swift */,
@@ -402,7 +409,6 @@
 				7DC7F0931E70C26B009E722B /* TestLocationManager.swift */,
 				7DC7F09B1E72066B009E722B /* TestMapzenManager.swift */,
 				7DC7F0971E71E138009E722B /* TestAnnotationTarget.swift */,
-				7DC7F0A11E770443009E722B /* RoutingControllerTests.swift */,
 				7D7D49941E7709A1006074EB /* TestUrlSession.swift */,
 				7D7D49921E7708E5006074EB /* TestSessionDataTask.swift */,
 				7D503BCF1E78944300FDDC4F /* TestTGMarkerPickResult.swift */,
@@ -410,6 +416,7 @@
 				7DB181541E81B745001F9B49 /* SearchDataObjectsTests.swift */,
 				7DB181561E81B77B001F9B49 /* SearchResponseTests.swift */,
 				7D4122731E84834C009520B7 /* SearchConfigsTests.swift */,
+				7DDF87581E8368F8001B01A8 /* MarkerTests.swift */,
 			);
 			path = "ios-sdkTests";
 			sourceTree = "<group>";
@@ -431,6 +438,8 @@
 				7DC7F0991E7204BE009E722B /* MapzenManagerExtensions.swift */,
 				7DB181481E81B681001F9B49 /* SearchResponse.swift */,
 				7D4122711E84621A009520B7 /* SearchConfigs.swift */,
+				7DB181581E831414001F9B49 /* Marker.swift */,
+				7DDF87541E832F38001B01A8 /* UIColorExtensions.swift */,
 			);
 			path = src;
 			sourceTree = "<group>";
@@ -669,12 +678,14 @@
 				DB22E59A1DA45D73004264E0 /* RoutingSearchVC.swift in Sources */,
 				DBBF368B1D64DA6A0069D769 /* RoutingViewController.swift in Sources */,
 				7DC7F09A1E7204BE009E722B /* MapzenManagerExtensions.swift in Sources */,
+				7DDF87551E832F38001B01A8 /* UIColorExtensions.swift in Sources */,
 				7D2FB7671E6103D500CB82CF /* DictionaryExtensions.swift in Sources */,
 				DB188EF01E2C44F40054DEFD /* RouteDisplayViewController.swift in Sources */,
 				7D503BCE1E77468B00FDDC4F /* SampleTableViewController.swift in Sources */,
 				DB22E59C1DA46640004264E0 /* RoutingResultTableVC.swift in Sources */,
 				DBC869901D3662DD00DDC4FE /* AutocompleteTableVC.swift in Sources */,
 				7D4122721E84621A009520B7 /* SearchConfigs.swift in Sources */,
+				7DB181591E831414001F9B49 /* Marker.swift in Sources */,
 				DB7A33D81C8F8E8B009CC743 /* AppDelegate.swift in Sources */,
 				7DB181441E81B472001F9B49 /* SearchDataConverter.swift in Sources */,
 			);
@@ -686,15 +697,16 @@
 			files = (
 				7D7DAE1D1E60C5C900FFCA6F /* TestApplication.swift in Sources */,
 				7D4122741E84834C009520B7 /* SearchConfigsTests.swift in Sources */,
+				7D5616D51E89706700D95E5D /* RoutingControllerTests.swift in Sources */,
 				7DC7F0941E70C26B009E722B /* TestLocationManager.swift in Sources */,
 				7DC7F0981E71E138009E722B /* TestAnnotationTarget.swift in Sources */,
 				7DB181551E81B745001F9B49 /* SearchDataObjectsTests.swift in Sources */,
 				7DF0AA2E1E5520ED00B0406E /* TestTGMapViewController.swift in Sources */,
 				7DB181571E81B77B001F9B49 /* SearchResponseTests.swift in Sources */,
+				7DDF87591E8368F8001B01A8 /* MarkerTests.swift in Sources */,
 				DB188EEC1E28492A0054DEFD /* MapzenManagerTests.swift in Sources */,
 				7DC7F09C1E72066B009E722B /* TestMapzenManager.swift in Sources */,
 				7D7D49951E7709A1006074EB /* TestUrlSession.swift in Sources */,
-				7DC7F0A21E770443009E722B /* RoutingControllerTests.swift in Sources */,
 				7D503BD01E78944300FDDC4F /* TestTGMarkerPickResult.swift in Sources */,
 				7DB181531E81B73A001F9B49 /* SearchDataConverterTests.swift in Sources */,
 				DBCBC5BF1E0AE1CF0045B345 /* MapViewControllerTests.swift in Sources */,

--- a/ios-sdkTests/MapViewControllerTests.swift
+++ b/ios-sdkTests/MapViewControllerTests.swift
@@ -16,7 +16,7 @@ class TestMapViewController: MapViewController {
   func lastSetPointValue() -> TGGeoPoint? {
     return lastSetPoint
   }
-  func currentLocationGemValue() -> TGMarker? {
+  func currentLocationGemValue() -> Marker? {
     return currentLocationGem
   }
   func shouldShowCurrentLocationValue() -> Bool {

--- a/ios-sdkTests/MapViewControllerTests.swift
+++ b/ios-sdkTests/MapViewControllerTests.swift
@@ -627,7 +627,10 @@ class MapViewControllerTests: XCTestCase {
   func testDidSelectMarkerCallsSelectDelegate() {
     let delegate = TestMapSelectDelegate()
     controller.markerSelectDelegate = delegate
-    controller.mapView(tgViewController, didSelectMarker: TGMarkerPickResult(), atScreenPosition: CGPoint())
+    let tgMarker = TGMarker()
+    let result = TestTGMarkerPickResult.init(marker: tgMarker)
+    controller.currentMarkers[tgMarker] = Marker()
+    controller.mapView(tgViewController, didSelectMarker: result, atScreenPosition: CGPoint())
     XCTAssertTrue(delegate.markerPicked)
   }
   
@@ -706,6 +709,23 @@ class MapViewControllerTests: XCTestCase {
     XCTAssertFalse(controller.findMeButton.isHidden)
     XCTAssertTrue(controller.findMeButton.isSelected) // Determined by shouldFollowCurrentLocation
     XCTAssertTrue(controller.findMeButton.isEnabled)
+  }
+
+  func testAddMarker() {
+    let tgMarker = TestTGMarker()
+    let marker = Marker(tgMarker: tgMarker)
+    controller.addMarker(marker)
+    XCTAssertEqual(controller.currentMarkers[marker.tgMarker], marker)
+    XCTAssertEqual(marker.tgMarker.map, controller.tgViewController)
+  }
+
+  func testRemoveMarker() {
+    let tgMarker = TestTGMarker()
+    let marker = Marker(tgMarker: tgMarker)
+    controller.addMarker(marker)
+    controller.removeMarker(marker)
+    XCTAssertNil(controller.currentMarkers[marker.tgMarker])
+    XCTAssertNil(marker.tgMarker.map)
   }
 }
 
@@ -831,7 +851,7 @@ class TestMapSelectDelegate : MapLabelSelectDelegate, MapMarkerSelectDelegate, M
     labelPicked = true
   }
   
-  func mapController(_ mapView: MapViewController, didSelectMarker markerPickResult: TGMarkerPickResult, atScreenPosition position: CGPoint) {
+  func mapController(_ mapView: MapViewController, didSelectMarker marker: Marker, atScreenPosition position: CGPoint) {
     markerPicked = true
   }
   

--- a/ios-sdkTests/MapViewControllerTests.swift
+++ b/ios-sdkTests/MapViewControllerTests.swift
@@ -16,7 +16,7 @@ class TestMapViewController: MapViewController {
   func lastSetPointValue() -> TGGeoPoint? {
     return lastSetPoint
   }
-  func currentLocationGemValue() -> Marker? {
+  func currentLocationGemValue() -> GenericMarker? {
     return currentLocationGem
   }
   func shouldShowCurrentLocationValue() -> Bool {
@@ -715,7 +715,8 @@ class MapViewControllerTests: XCTestCase {
     let tgMarker = TestTGMarker()
     let marker = Marker(tgMarker: tgMarker)
     controller.addMarker(marker)
-    XCTAssertEqual(controller.currentMarkers[marker.tgMarker], marker)
+    let m = controller.currentMarkers[marker.tgMarker] as! Marker
+    XCTAssertEqual(m, marker)
     XCTAssertEqual(marker.tgMarker.map, controller.tgViewController)
   }
 
@@ -851,7 +852,7 @@ class TestMapSelectDelegate : MapLabelSelectDelegate, MapMarkerSelectDelegate, M
     labelPicked = true
   }
   
-  func mapController(_ mapView: MapViewController, didSelectMarker marker: Marker, atScreenPosition position: CGPoint) {
+  func mapController(_ mapView: MapViewController, didSelectMarker marker: GenericMarker, atScreenPosition position: CGPoint) {
     markerPicked = true
   }
   

--- a/ios-sdkTests/MarkerTests.swift
+++ b/ios-sdkTests/MarkerTests.swift
@@ -1,0 +1,139 @@
+//
+//  MarkerTests.swift
+//  ios-sdk
+//
+//  Created by Sarah Lensing on 3/22/17.
+//  Copyright © 2017 Mapzen. All rights reserved.
+//
+
+import XCTest
+@testable import ios_sdk
+import TangramMap
+
+class MarkerTests: XCTestCase {
+
+  let marker = Marker()
+
+  func testPoint() {
+    let point = TGGeoPoint(longitude: 70.0, latitude: 40.0)
+    marker.point = point
+    XCTAssertEqual(marker.point?.latitude, point.latitude)
+    XCTAssertEqual(marker.point?.longitude, point.longitude)
+    XCTAssertEqual(marker.tgMarker.point.latitude, point.latitude)
+    XCTAssertEqual(marker.tgMarker.point.longitude, point.longitude)
+    XCTAssertTrue(marker.tgMarker.stylingString.contains("style: 'points'"))
+  }
+
+  func testPolyline() {
+    let polyline = TGGeoPolyline()
+    marker.polyline = polyline
+    XCTAssertEqual(marker.polyline, polyline)
+    XCTAssertEqual(marker.tgMarker.polyline, polyline)
+    XCTAssertTrue(marker.tgMarker.stylingString.contains("style: 'lines'"))
+  }
+
+  func testPolygon() {
+    let polygon = TGGeoPolygon()
+    marker.polygon = polygon
+    XCTAssertEqual(marker.polygon, polygon)
+    XCTAssertEqual(marker.tgMarker.polygon, polygon)
+    XCTAssertTrue(marker.tgMarker.stylingString.contains("style: 'polygons'"))
+  }
+
+  //TODO: failing, fix
+//  func testIcon() {
+//    let icon = UIImage(named: "ic_find_me_normal")
+//    let map = MapViewController()
+//    _ = map.view
+//    try? map.loadStyle(.bubbleWrap)
+//    map.addMarker(marker)
+//    marker.icon = icon
+//    XCTAssertEqual(marker.icon, icon)
+//    XCTAssertEqual(marker.tgMarker.icon, icon)
+//    XCTAssertTrue(marker.tgMarker.stylingString.contains("style: 'points'"))
+//    XCTAssertEqual(marker.size, icon?.size)
+//    XCTAssertTrue(marker.tgMarker.stylingString.contains("size: [\(icon?.size.width)px, \(icon?.size.height)px]"))
+//  }
+
+  func testVisible() {
+    XCTAssertTrue(marker.visible)
+    XCTAssertTrue(marker.tgMarker.visible)
+    marker.visible = false
+    XCTAssertFalse(marker.visible)
+    XCTAssertFalse(marker.tgMarker.visible)
+  }
+
+  func testDrawOrder() {
+    XCTAssertEqual(marker.drawOrder, 0)
+    XCTAssertEqual(marker.tgMarker.drawOrder, 0)
+    marker.drawOrder = 8
+    XCTAssertEqual(marker.drawOrder, 8)
+    XCTAssertEqual(marker.tgMarker.drawOrder, 8)
+  }
+
+  func testSize() {
+    XCTAssertEqual(marker.size, CGSize.zero)
+    let size = CGSize(width: 8, height: 8)
+    marker.size = size
+    XCTAssertEqual(marker.size, size)
+    XCTAssertTrue(marker.tgMarker.stylingString.contains("size: [\(size.width)px, \(size.height)px]"))
+  }
+
+  func testBackgroundColor() {
+    XCTAssertEqual(marker.backgroundColor, UIColor.white)
+    let bgColor = UIColor.red
+    marker.backgroundColor = bgColor
+    let hex = bgColor.hexValue()
+    XCTAssertEqual(marker.backgroundColor, bgColor)
+    XCTAssertTrue(marker.tgMarker.stylingString.contains("color: '\(hex)'"))
+  }
+
+  func testInteractive() {
+    XCTAssertTrue(marker.interactive)
+    marker.interactive = false
+    XCTAssertFalse(marker.interactive)
+    XCTAssertTrue(marker.tgMarker.stylingString.contains("interactive: false"))
+  }
+
+  func testInitWithSize() {
+    let size = CGSize(width: 30, height: 30)
+    let m = Marker.init(size: size)
+    XCTAssertEqual(m.size, size)
+    XCTAssertEqual(m.backgroundColor, UIColor.white)
+    XCTAssertTrue(m.interactive)
+  }
+
+//  func testInitWithIcon() {
+//    let image = UIImage(named: "ic_find_me_normal")
+//    let m = Marker.init(icon: image)
+//    XCTAssertEqual(m.size, image?.size)
+//    XCTAssertEqual(m.backgroundColor, UIColor.white)
+//    XCTAssertTrue(m.interactive)
+//    XCTAssertEqual(m.icon, image)
+//  }
+
+  func testSetPointEased() {
+    let point = TGGeoPoint(longitude: 70.0, latitude: 40.0)
+    let tgMarker = TestTGMarker()
+    let m = Marker(tgMarker: tgMarker)
+    _ = m.setPointEased(point, seconds: 4, easeType: .linear)
+    XCTAssertEqual(tgMarker.coordinates.latitude, 40.0)
+    XCTAssertEqual(tgMarker.coordinates.longitude, 70.0)
+    XCTAssertEqual(tgMarker.seconds, 4)
+    XCTAssertEqual(tgMarker.ease, .linear)
+  }
+}
+
+class TestTGMarker : TGMarker {
+
+  var coordinates: TGGeoPoint = TGGeoPoint()
+  var seconds: Float = 0
+  var ease: TGEaseType = .cubic
+
+  open override func setPointEased(_ c: TGGeoPoint, seconds s: Float, easeType e: TGEaseType) -> Bool {
+    coordinates = c
+    seconds = s
+    ease = e
+    return true
+  }
+}

--- a/ios-sdkTests/MarkerTests.swift
+++ b/ios-sdkTests/MarkerTests.swift
@@ -122,6 +122,25 @@ class MarkerTests: XCTestCase {
     XCTAssertEqual(tgMarker.seconds, 4)
     XCTAssertEqual(tgMarker.ease, .linear)
   }
+
+  func testTypeCurrentLocation() {
+    let m = Marker.initWithMarkerType(.currentLocation)
+    XCTAssertEqual(m.tgMarker.stylingPath, "layers.mz_current_location_gem.draw.ux-location-gem-overlay")
+    XCTAssertTrue(m.tgMarker.stylingString.isEmpty)
+  }
+
+  func testTypeSearchPin() {
+    let m = Marker.initWithMarkerType(.searchPin)
+    XCTAssertEqual(m.tgMarker.stylingPath, "layers.mz_search_result.draw.ux-icons-overlay")
+    XCTAssertTrue(m.tgMarker.stylingString.isEmpty)
+  }
+
+  func testTypeRouteLine() {
+    let m = Marker.initWithMarkerType(.routeLine)
+    XCTAssertEqual(m.tgMarker.stylingPath, "layers.mz_route_line.draw.ux-route-line-overlay")
+    XCTAssertTrue(m.tgMarker.stylingString.isEmpty)
+  }
+
 }
 
 class TestTGMarker : TGMarker {

--- a/ios-sdkTests/MarkerTests.swift
+++ b/ios-sdkTests/MarkerTests.swift
@@ -22,7 +22,7 @@ class MarkerTests: XCTestCase {
     XCTAssertEqual(marker.tgMarker.point.latitude, point.latitude)
     XCTAssertEqual(marker.tgMarker.point.longitude, point.longitude)
     XCTAssertTrue(marker.tgMarker.stylingString.contains("style: 'points'"))
-    XCTAssertTrue(marker.tgMarker.stylingString.contains("size:"))
+    XCTAssertFalse(marker.tgMarker.stylingString.contains("size:"))
   }
 
   func testPolyline() {
@@ -104,8 +104,16 @@ class MarkerTests: XCTestCase {
     XCTAssertEqual(m.size, size)
     XCTAssertEqual(m.backgroundColor, UIColor.white)
     XCTAssertTrue(m.interactive)
+    XCTAssertTrue(m.tgMarker.stylingString.contains("size: [\(size.width)px, \(size.height)px]"))
   }
 
+  func testInit() {
+    let m = Marker.init()
+    XCTAssertEqual(m.backgroundColor, UIColor.white)
+    XCTAssertTrue(m.interactive)
+    XCTAssertFalse(m.tgMarker.stylingString.contains("size:"))
+  }
+  
 //  func testInitWithIcon() {
 //    let image = UIImage(named: "ic_find_me_normal")
 //    let m = Marker.init(icon: image)

--- a/ios-sdkTests/MarkerTests.swift
+++ b/ios-sdkTests/MarkerTests.swift
@@ -171,6 +171,17 @@ class TestTGMarker : TGMarker {
   var seconds: Float = 0
   var ease: TGEaseType = .cubic
 
+  private var internalMap: TGMapViewController?
+
+  override public var map : TGMapViewController? {
+    set {
+      internalMap = newValue
+    }
+    get {
+      return internalMap
+    }
+  }
+
   open override func setPointEased(_ c: TGGeoPoint, seconds s: Float, easeType e: TGEaseType) -> Bool {
     coordinates = c
     seconds = s

--- a/ios-sdkTests/MarkerTests.swift
+++ b/ios-sdkTests/MarkerTests.swift
@@ -141,6 +141,28 @@ class MarkerTests: XCTestCase {
     XCTAssertTrue(m.tgMarker.stylingString.isEmpty)
   }
 
+  func testTypeCurrentLocationInactive() {
+    let m = Marker.initWithMarkerType(.currentLocation)
+    m.active = false
+    // there is no inactive draw rule for curr location so its same as active state
+    XCTAssertEqual(m.tgMarker.stylingPath, "layers.mz_current_location_gem.draw.ux-location-gem-overlay")
+    XCTAssertTrue(m.tgMarker.stylingString.isEmpty)
+  }
+
+  func testTypeSearchPinInactive() {
+    let m = Marker.initWithMarkerType(.searchPin)
+    m.active = false
+    XCTAssertEqual(m.tgMarker.stylingPath, "layers.mz_search_result.inactive.draw.ux-icons-overlay")
+    XCTAssertTrue(m.tgMarker.stylingString.isEmpty)
+  }
+
+  func testTypeRouteLineInactive() {
+    let m = Marker.initWithMarkerType(.routeLine)
+    m.active = false
+    // there is no inactive draw rule for route line so its same as active state
+    XCTAssertEqual(m.tgMarker.stylingPath, "layers.mz_route_line.draw.ux-route-line-overlay")
+    XCTAssertTrue(m.tgMarker.stylingString.isEmpty)
+  }
 }
 
 class TestTGMarker : TGMarker {

--- a/ios-sdkTests/MarkerTests.swift
+++ b/ios-sdkTests/MarkerTests.swift
@@ -17,8 +17,8 @@ class MarkerTests: XCTestCase {
   func testPoint() {
     let point = TGGeoPoint(longitude: 70.0, latitude: 40.0)
     marker.point = point
-    XCTAssertEqual(marker.point?.latitude, point.latitude)
-    XCTAssertEqual(marker.point?.longitude, point.longitude)
+    XCTAssertEqual(marker.point.latitude, point.latitude)
+    XCTAssertEqual(marker.point.longitude, point.longitude)
     XCTAssertEqual(marker.tgMarker.point.latitude, point.latitude)
     XCTAssertEqual(marker.tgMarker.point.longitude, point.longitude)
     XCTAssertTrue(marker.tgMarker.stylingString.contains("style: 'points'"))

--- a/ios-sdkTests/MarkerTests.swift
+++ b/ios-sdkTests/MarkerTests.swift
@@ -22,6 +22,7 @@ class MarkerTests: XCTestCase {
     XCTAssertEqual(marker.tgMarker.point.latitude, point.latitude)
     XCTAssertEqual(marker.tgMarker.point.longitude, point.longitude)
     XCTAssertTrue(marker.tgMarker.stylingString.contains("style: 'points'"))
+    XCTAssertTrue(marker.tgMarker.stylingString.contains("size:"))
   }
 
   func testPolyline() {
@@ -30,6 +31,7 @@ class MarkerTests: XCTestCase {
     XCTAssertEqual(marker.polyline, polyline)
     XCTAssertEqual(marker.tgMarker.polyline, polyline)
     XCTAssertTrue(marker.tgMarker.stylingString.contains("style: 'lines'"))
+    XCTAssertFalse(marker.tgMarker.stylingString.contains("size:"))
   }
 
   func testPolygon() {
@@ -38,6 +40,7 @@ class MarkerTests: XCTestCase {
     XCTAssertEqual(marker.polygon, polygon)
     XCTAssertEqual(marker.tgMarker.polygon, polygon)
     XCTAssertTrue(marker.tgMarker.stylingString.contains("style: 'polygons'"))
+    XCTAssertFalse(marker.tgMarker.stylingString.contains("size:"))
   }
 
   //TODO: failing, fix

--- a/ios-sdkTests/TestAnnotationTarget.swift
+++ b/ios-sdkTests/TestAnnotationTarget.swift
@@ -24,7 +24,7 @@ class AnnotationTestTarget : UIResponder, MapMarkerSelectDelegate {
     annotationClickedNoParam = true
   }
 
-  func mapController(_ controller: MapViewController, didSelectMarker marker: Marker, atScreenPosition position: CGPoint) {
+  func mapController(_ controller: MapViewController, didSelectMarker marker: GenericMarker, atScreenPosition position: CGPoint) {
     markerSelected = true
   }
 }

--- a/ios-sdkTests/TestAnnotationTarget.swift
+++ b/ios-sdkTests/TestAnnotationTarget.swift
@@ -24,7 +24,7 @@ class AnnotationTestTarget : UIResponder, MapMarkerSelectDelegate {
     annotationClickedNoParam = true
   }
 
-  func mapController(_ controller: MapViewController, didSelectMarker markerPickResult: TGMarkerPickResult, atScreenPosition position: CGPoint) {
+  func mapController(_ controller: MapViewController, didSelectMarker marker: Marker, atScreenPosition position: CGPoint) {
     markerSelected = true
   }
 }

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -481,6 +481,24 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
     tgViewController.animate(toTilt: radians, withDuration: seconds, with: easeType)
   }
 
+  /**
+   Adds a marker to the map. A marker can only be added to one map at a time.
+   
+   - parameter marker: The marker to add to map.
+   */
+  open func addMarker(_ marker: Marker) {
+    marker.tgMarker.map = tgViewController
+  }
+
+  /**
+   Removes a marker from the map.
+
+   - parameter marker: The marker to remove from map.
+   */
+  open func removeMarker(_ marker: Marker) {
+    marker.tgMarker.map = nil
+  }
+
   /// Removes all existing markers on the map.
   open func markerRemoveAll() {
     tgViewController.markerRemoveAll()

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -871,8 +871,11 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
       addMarker(newMarker)
       //TODO: also set polyline, polygon etc
       newMarker.point = marker.point
-      newMarker.tgMarker.stylingString = marker.stylingString
-      newMarker.tgMarker.stylingPath = marker.stylingPath
+      if !marker.stylingPath.isEmpty {
+        newMarker.tgMarker.stylingPath = marker.stylingPath
+      } else {
+        newMarker.tgMarker.stylingString = marker.stylingString
+      }
       self.currentAnnotations[annotation] = newMarker.tgMarker
     }
 

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -180,10 +180,10 @@ public protocol MapMarkerSelectDelegate : class {
    Informs the delegate a marker of the map was just selected
 
    - parameter controller: The MapViewController that recognized the selection.
-   - parameter markerPickResult: A marker selection returned as an instance of Marker.
+   - parameter markerPickResult: A marker selection returned as an instance conforming to GenericMarker.
    - parameter atScreenPosition: The screen coordinates of the picked marker.
    */
-  func mapController(_ controller: MapViewController, didSelectMarker marker: Marker, atScreenPosition position: CGPoint)
+  func mapController(_ controller: MapViewController, didSelectMarker marker: GenericMarker, atScreenPosition position: CGPoint)
 }
 
 /// MapTileLoadDelegate
@@ -215,15 +215,15 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
 
   let application : ApplicationProtocol
   open var tgViewController: TGMapViewController = TGMapViewController()
-  var currentLocationGem: Marker?
+  var currentLocationGem: GenericMarker?
   var lastSetPoint: TGGeoPoint?
   var shouldShowCurrentLocation = false
-  var currentRouteMarker: Marker?
+  var currentRouteMarker: GenericMarker?
   var currentRoute: OTRRoutingResult?
   open var shouldFollowCurrentLocation = false
   open var findMeButton = UIButton(type: .custom)
   var currentAnnotations: [PeliasMapkitAnnotation : TGMarker] = Dictionary()
-  var currentMarkers: [TGMarker : Marker] = Dictionary()
+  var currentMarkers: [TGMarker : GenericMarker] = Dictionary()
   open var attributionBtn = UIButton()
   private var locale = Locale.current
   var stateSaver: StateReclaimer?
@@ -487,7 +487,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
    
    - parameter marker: The marker to add to map.
    */
-  open func addMarker(_ marker: Marker) {
+  open func addMarker(_ marker: GenericMarker) {
     currentMarkers[marker.tgMarker] = marker
     marker.tgMarker.map = tgViewController
   }
@@ -497,7 +497,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
 
    - parameter marker: The marker to remove from map.
    */
-  open func removeMarker(_ marker: Marker) {
+  open func removeMarker(_ marker: GenericMarker) {
     currentMarkers.removeValue(forKey: marker.tgMarker)
     marker.tgMarker.map = nil
   }

--- a/src/Marker.swift
+++ b/src/Marker.swift
@@ -9,6 +9,10 @@
 import Foundation
 import TangramMap
 
+public enum MarkerType : Int {
+  case currentLocation, searchPin, routeLine
+}
+
 @objc(MZMarker)
 public class Marker: NSObject {
 
@@ -21,6 +25,9 @@ public class Marker: NSObject {
 
   public let tgMarker: TGMarker
   private var styleType = kPointStyle
+  private static let typeToStylingPath = [MarkerType.currentLocation : "layers.mz_current_location_gem.draw.ux-location-gem-overlay",
+                                   MarkerType.searchPin : "layers.mz_search_result.draw.ux-icons-overlay",
+                                   MarkerType.routeLine : "layers.mz_route_line.draw.ux-route-line-overlay"]
 
   open var point: TGGeoPoint? {
     set {
@@ -106,6 +113,12 @@ public class Marker: NSObject {
     }
   }
 
+  public static func initWithMarkerType(_ markerType: MarkerType) -> Marker {
+    let stylingPath = Marker.typeToStylingPath[markerType]
+    let marker = Marker(stylingPath: stylingPath!)
+    return marker
+  }
+
   public override convenience init() {
     self.init(size: Marker.kDefaultSize)
   }
@@ -134,12 +147,20 @@ public class Marker: NSObject {
     interactive = Marker.kDefaultInteractive
   }
 
+  convenience init(stylingPath: String) {
+    self.init(size: Marker.kDefaultSize)
+    tgMarker.stylingPath = stylingPath
+  }
+
   open func setPointEased(_ coordinates: TGGeoPoint, seconds: Float, easeType ease: TGEaseType) -> Bool {
     return tgMarker.setPointEased(coordinates, seconds: seconds, easeType: ease)
   }
 
   // MARK : private
   private func updateStyleString() {
+    if !tgMarker.stylingPath.isEmpty {
+      return
+    }
     let str = "{ style: '\(styleType)', color: '\(backgroundColor.hexValue())', size: [\(size.width)px, \(size.height)px], collide: false, interactive: \(interactive) }"
     print("str: \(str)")
     tgMarker.stylingString = str

--- a/src/Marker.swift
+++ b/src/Marker.swift
@@ -9,31 +9,59 @@
 import Foundation
 import TangramMap
 
+/// Enum for common marker types supported by all the house styles.
 @objc public enum MarkerType : Int {
   case currentLocation, searchPin, routeLine
 }
 
+/// Generic marker protocol definition.
 @objc(MZGenericMarker)
 public protocol GenericMarker {
+  /// The underlying Tangram marker object. Use this only for advanced cases where features of the Marker class aren't supported.
   var tgMarker: TGMarker { get }
+  /// The coordinates that the marker should be placed at on the map. Note that point, polyline, and polygon are mutually exclusive. Setting one will overwrite the other values
   var point: TGGeoPoint { get set }
+  /// The polyline that should be displayed on the map. Note that point, polyline, and polygon are mutually exclusive. Setting one will overwrite the other values
   var polyline: TGGeoPolyline? { get set }
+  /// The polygon that should be displayed on the map. Note that point, polyline, and polygon are mutually exclusive. Setting one will overwrite the other values
   var polygon: TGGeoPolygon? { get set }
+  /// The image that should be displayed on the marker. This cannot be used with polylines or polygons, only points.
   var icon: UIImage? { get set }
+  /// Toggles the marker visibility.
   var visible: Bool { get set }
+  /// The marker draw order relative to other markers. Note that higher values are drawn above lower ones.
   var drawOrder: Int { get set }
+  /// Sets the size of a point marker. Does nothing when a polyline or polygon is set.
   var size: CGSize { get set }
+  /// Sets the marker background color. Default value is white.
   var backgroundColor: UIColor { get set }
+  /// If the marker is interactive, it is able to be selected and delegates can receive callbacks for these events. Default value is true.
   var interactive: Bool { get set }
+  /// Should only be used when a marker is initialized with a MarkerType. Updates the visual properties to indicate active status (ie. updates search pin to be gray when inactive).
   var active: Bool { get set }
-
+  /**
+   Animates the marker from its current coordinates to the ones given.
+   
+   - parameter coordinates: Coordinates to animate the marker to
+   - parameter seconds: Duration in seconds of the animation.
+   - parameter easeType: Easing to use for animation.
+  */
   func setPointEased(_ coordinates: TGGeoPoint, seconds: Float, easeType ease: TGEaseType) -> Bool
-
+  /// Returns a marker whose visual properties have been defined by a house style. Do not try to update the background color, size or other visual aspects of this marker.
   static func initWithMarkerType(_ markerType: MarkerType) -> GenericMarker
+  /// Default initializer.
   init()
+  /**
+   Initializes a marker with a given size.
+   
+   - parameter size: The size the marker should be.
+   */
   init(size s: CGSize)
 }
 
+/**
+ Base implementation for the GenericMarker protocol
+ */
 public class Marker : NSObject, GenericMarker {
 
   private static let kPointStyle = "points"
@@ -57,12 +85,14 @@ public class Marker : NSObject, GenericMarker {
   private let internalTgMarker: TGMarker
   private var userUpdatedSize = false
 
+  /// The underlying Tangram marker object. Use this only for advanced cases where features of the Marker class aren't supported.
   public var tgMarker: TGMarker {
     get {
       return internalTgMarker
     }
   }
 
+  /// The coordinates that the marker should be placed at on the map. Note that point, polyline, and polygon are mutually exclusive. Setting one will overwrite the other values
   public var point: TGGeoPoint {
     set {
       tgMarker.point = newValue
@@ -74,6 +104,7 @@ public class Marker : NSObject, GenericMarker {
     }
   }
 
+  /// The polyline that should be displayed on the map. Note that point, polyline, and polygon are mutually exclusive. Setting one will overwrite the other values
   public var polyline: TGGeoPolyline? {
     set {
       guard let l  = newValue else { return }
@@ -86,6 +117,7 @@ public class Marker : NSObject, GenericMarker {
     }
   }
 
+  /// The polygon that should be displayed on the map. Note that point, polyline, and polygon are mutually exclusive. Setting one will overwrite the other values
   public var polygon: TGGeoPolygon? {
     set {
       guard let p = newValue else { return }
@@ -97,6 +129,8 @@ public class Marker : NSObject, GenericMarker {
       return tgMarker.polygon
     }
   }
+
+  /// The image that should be displayed on the marker. Updates the size of the marker to be the intrinsic size of the image. This cannot be used with polylines or polygons, only points.
   public var icon: UIImage? {
     set {
       guard let i = newValue else { return }
@@ -110,6 +144,7 @@ public class Marker : NSObject, GenericMarker {
     }
   }
 
+  /// Toggles the marker visibility.
   public var visible: Bool {
     set {
       tgMarker.visible = newValue
@@ -119,6 +154,7 @@ public class Marker : NSObject, GenericMarker {
     }
   }
 
+  /// The marker draw order relative to other markers. Note that higher values are drawn above lower ones.
   public var drawOrder: Int {
     set {
       tgMarker.drawOrder = newValue
@@ -128,6 +164,7 @@ public class Marker : NSObject, GenericMarker {
     }
   }
 
+  /// Sets the size of a point marker. Does nothing when a polyline or polygon is set.
   public var size: CGSize {
     didSet {
       userUpdatedSize = true
@@ -135,34 +172,45 @@ public class Marker : NSObject, GenericMarker {
     }
   }
 
+  /// Sets the marker background color. Default value is white.
   public var backgroundColor: UIColor {
     didSet {
       updateStyleString()
     }
   }
 
+  /// If the marker is interactive, it is able to be selected and delegates can receive callbacks for these events. Default value is true.
   public var interactive: Bool {
     didSet {
       updateStyleString()
     }
   }
 
+  /// Should only be used when a marker is initialized with a MarkerType. Updates the visual properties to indicate active status (ie. updates search pin to be gray when inactive).
   public var active: Bool {
     didSet {
       updateStylePath()
     }
   }
 
+  /**
+   Animates the marker from its current coordinates to the ones given.
+
+   - parameter coordinates: Coordinates to animate the marker to
+   - parameter seconds: Duration in seconds of the animation.
+   - parameter easeType: Easing to use for animation.
+   */
   public func setPointEased(_ coordinates: TGGeoPoint, seconds: Float, easeType ease: TGEaseType) -> Bool {
     return tgMarker.setPointEased(coordinates, seconds: seconds, easeType: ease)
   }
 
-
+  /// Returns a marker whose visual properties have been defined by a house style. Do not try to update the background color, size or other visual aspects of this marker.
   public static func initWithMarkerType(_ markerType: MarkerType) -> GenericMarker {
     let marker = Marker(markerType: markerType)
     return marker
   }
 
+  /// Default initializer.
   public required override init() {
     internalTgMarker = TGMarker.init()
     size = Marker.kDefaultSize
@@ -181,6 +229,11 @@ public class Marker : NSObject, GenericMarker {
   //    icon = i
   //  }
 
+  /**
+   Initializes a marker with a given size.
+
+   - parameter size: The size the marker should be.
+   */
   public required init(size s: CGSize) {
     internalTgMarker = TGMarker.init()
     size = s

--- a/src/Marker.swift
+++ b/src/Marker.swift
@@ -1,0 +1,147 @@
+//
+//  Marker.swift
+//  ios-sdk
+//
+//  Created by Sarah Lensing on 3/22/17.
+//  Copyright © 2017 Mapzen. All rights reserved.
+//
+
+import Foundation
+import TangramMap
+
+@objc(MZMarker)
+public class Marker: NSObject {
+
+  private static let kPointStyle = "points"
+  private static let kLineStyle = "lines"
+  private static let kPolygonStyle = "polygons"
+  private static let kDefaultBackgroundColor = UIColor.white
+  private static let kDefaultInteractive = true
+  private static let kDefaultSize = CGSize.zero
+
+  public let tgMarker: TGMarker
+  private var styleType = kPointStyle
+
+  open var point: TGGeoPoint? {
+    set {
+      guard let p = newValue else { return }
+      tgMarker.point = p
+      styleType = Marker.kPointStyle
+      updateStyleString()
+    }
+    get {
+      return tgMarker.point
+    }
+  }
+
+  open var polyline: TGGeoPolyline? {
+    set {
+      guard let l  = newValue else { return }
+      tgMarker.polyline = l
+      styleType = Marker.kLineStyle
+      updateStyleString()
+    }
+    get {
+      return tgMarker.polyline
+    }
+  }
+
+  open var polygon: TGGeoPolygon? {
+    set {
+      guard let p = newValue else { return }
+      tgMarker.polygon = p
+      styleType = Marker.kPolygonStyle
+      updateStyleString()
+    }
+    get {
+      return tgMarker.polygon
+    }
+  }
+  open var icon: UIImage? {
+    set {
+      guard let i = newValue else { return }
+      tgMarker.icon = i
+      size = i.size
+      styleType = Marker.kPointStyle
+      updateStyleString()
+    }
+    get {
+      return tgMarker.icon
+    }
+  }
+
+  open var visible: Bool {
+    set {
+      tgMarker.visible = newValue
+    }
+    get {
+      return tgMarker.visible
+    }
+  }
+
+  open var drawOrder: Int {
+    set {
+      tgMarker.drawOrder = newValue
+    }
+    get {
+      return tgMarker.drawOrder
+    }
+  }
+
+  open var size: CGSize {
+    didSet {
+      updateStyleString()
+    }
+  }
+
+  open var backgroundColor: UIColor {
+    didSet {
+      updateStyleString()
+    }
+  }
+
+  open var interactive: Bool {
+    didSet {
+      updateStyleString()
+    }
+  }
+
+  public override convenience init() {
+    self.init(size: Marker.kDefaultSize)
+  }
+
+//TODO: add back when https://github.com/tangrams/tangram-es/issues/1394 is fixed
+//  public convenience init(icon i: UIImage?) {
+//    if let sz = i?.size {
+//      self.init(size: sz)
+//    } else {
+//      self.init(size: Marker.kDefaultSize)
+//    }
+//    icon = i
+//  }
+
+  public init(size s: CGSize) {
+    tgMarker = TGMarker.init()
+    size = s
+    backgroundColor = Marker.kDefaultBackgroundColor
+    interactive = Marker.kDefaultInteractive
+  }
+
+  init(tgMarker tgM: TGMarker) {
+    tgMarker = tgM
+    size = Marker.kDefaultSize
+    backgroundColor = Marker.kDefaultBackgroundColor
+    interactive = Marker.kDefaultInteractive
+  }
+
+  open func setPointEased(_ coordinates: TGGeoPoint, seconds: Float, easeType ease: TGEaseType) -> Bool {
+    return tgMarker.setPointEased(coordinates, seconds: seconds, easeType: ease)
+  }
+
+  // MARK : private
+  private func updateStyleString() {
+    let str = "{ style: '\(styleType)', color: '\(backgroundColor.hexValue())', size: [\(size.width)px, \(size.height)px], collide: false, interactive: \(interactive) }"
+    print("str: \(str)")
+    tgMarker.stylingString = str
+  }
+}

--- a/src/Marker.swift
+++ b/src/Marker.swift
@@ -171,8 +171,19 @@ public class Marker: NSObject {
     if !tgMarker.stylingPath.isEmpty {
       return
     }
-    let str = "{ style: '\(styleType)', color: '\(backgroundColor.hexValue())', size: [\(size.width)px, \(size.height)px], collide: false, interactive: \(interactive) }"
-    print("str: \(str)")
+
+    var str: String
+    switch styleType {
+    case Marker.kPointStyle:
+      str = "{ style: '\(styleType)', color: '\(backgroundColor.hexValue())', size: [\(size.width)px, \(size.height)px], collide: false, interactive: \(interactive) }"
+      break;
+    case Marker.kLineStyle,
+         Marker.kPolygonStyle:
+      str = "{ style: '\(styleType)', color: '\(backgroundColor.hexValue())', collide: false, interactive: \(interactive) }"
+      break;
+    default:
+      str = "{ style: '\(styleType)', color: '\(backgroundColor.hexValue())', size: [\(size.width)px, \(size.height)px], collide: false, interactive: \(interactive) }"
+    }
     tgMarker.stylingString = str
   }
 

--- a/src/Marker.swift
+++ b/src/Marker.swift
@@ -34,25 +34,25 @@ public protocol GenericMarker {
   init(size s: CGSize)
 }
 
-private let kPointStyle = "points"
-private let kLineStyle = "lines"
-private let kPolygonStyle = "polygons"
-private let kDefaultBackgroundColor = UIColor.white
-private let kDefaultInteractive = true
-private let kDefaultSize = CGSize.zero
-private let kDefaultActive = true
-
-var styleType = kPointStyle
-var markerType: MarkerType?
-
-// all marker types have an associated styling path
-private let typeToStylingPath = [MarkerType.currentLocation : "layers.mz_current_location_gem.draw.ux-location-gem-overlay",
-                                MarkerType.searchPin : "layers.mz_search_result.draw.ux-icons-overlay",
-                                MarkerType.routeLine : "layers.mz_route_line.draw.ux-route-line-overlay"]
-//currently only search results have an inactive state
-private let typeToInactiveStylingPath = [MarkerType.searchPin : "layers.mz_search_result.inactive.draw.ux-icons-overlay"]
-
 public class Marker : GenericMarker {
+
+  private static let kPointStyle = "points"
+  private static let kLineStyle = "lines"
+  private static let kPolygonStyle = "polygons"
+  private static let kDefaultBackgroundColor = UIColor.white
+  private static let kDefaultInteractive = true
+  private static let kDefaultSize = CGSize.zero
+  private static let kDefaultActive = true
+
+  var styleType = Marker.kPointStyle
+  var markerType: MarkerType?
+
+  // all marker types have an associated styling path
+  private let typeToStylingPath = [MarkerType.currentLocation : "layers.mz_current_location_gem.draw.ux-location-gem-overlay",
+                                   MarkerType.searchPin : "layers.mz_search_result.draw.ux-icons-overlay",
+                                   MarkerType.routeLine : "layers.mz_route_line.draw.ux-route-line-overlay"]
+  //currently only search results have an inactive state
+  private let typeToInactiveStylingPath = [MarkerType.searchPin : "layers.mz_search_result.inactive.draw.ux-icons-overlay"]
 
   private let internalTgMarker: TGMarker
 
@@ -65,7 +65,7 @@ public class Marker : GenericMarker {
   public var point: TGGeoPoint {
     set {
       tgMarker.point = newValue
-      styleType = kPointStyle
+      styleType = Marker.kPointStyle
       updateStyleString()
     }
     get {
@@ -77,7 +77,7 @@ public class Marker : GenericMarker {
     set {
       guard let l  = newValue else { return }
       tgMarker.polyline = l
-      styleType = kLineStyle
+      styleType = Marker.kLineStyle
       updateStyleString()
     }
     get {
@@ -89,7 +89,7 @@ public class Marker : GenericMarker {
     set {
       guard let p = newValue else { return }
       tgMarker.polygon = p
-      styleType = kPolygonStyle
+      styleType = Marker.kPolygonStyle
       updateStyleString()
     }
     get {
@@ -101,7 +101,7 @@ public class Marker : GenericMarker {
       guard let i = newValue else { return }
       tgMarker.icon = i
       size = i.size
-      styleType = kPointStyle
+      styleType = Marker.kPointStyle
       updateStyleString()
     }
     get {
@@ -162,7 +162,7 @@ public class Marker : GenericMarker {
   }
 
   public convenience required init() {
-    self.init(size: kDefaultSize)
+    self.init(size: Marker.kDefaultSize)
   }
 
   //TODO: add back when https://github.com/tangrams/tangram-es/issues/1394 is fixed
@@ -178,21 +178,21 @@ public class Marker : GenericMarker {
   public required init(size s: CGSize) {
     internalTgMarker = TGMarker.init()
     size = s
-    backgroundColor = kDefaultBackgroundColor
-    interactive = kDefaultInteractive
-    active = kDefaultActive
+    backgroundColor = Marker.kDefaultBackgroundColor
+    interactive = Marker.kDefaultInteractive
+    active = Marker.kDefaultActive
   }
 
   init(tgMarker tgM: TGMarker) {
     internalTgMarker = tgM
-    size = kDefaultSize
-    backgroundColor = kDefaultBackgroundColor
-    interactive = kDefaultInteractive
-    active = kDefaultActive
+    size = Marker.kDefaultSize
+    backgroundColor = Marker.kDefaultBackgroundColor
+    interactive = Marker.kDefaultInteractive
+    active = Marker.kDefaultActive
   }
 
   convenience init(markerType mt: MarkerType) {
-    self.init(size: kDefaultSize)
+    self.init(size: Marker.kDefaultSize)
     markerType = mt
     tgMarker.stylingPath = typeToStylingPath[mt]! //there is always a styling string for a given MarkerType so force unwrap
   }
@@ -205,11 +205,11 @@ public class Marker : GenericMarker {
 
     var str: String
     switch styleType {
-    case kPointStyle:
+    case Marker.kPointStyle:
       str = "{ style: '\(styleType)', color: '\(backgroundColor.hexValue())', size: [\(size.width)px, \(size.height)px], collide: false, interactive: \(interactive) }"
       break;
-    case kLineStyle,
-         kPolygonStyle:
+    case Marker.kLineStyle,
+         Marker.kPolygonStyle:
       str = "{ style: '\(styleType)', color: '\(backgroundColor.hexValue())', collide: false, interactive: \(interactive) }"
       break;
     default:
@@ -233,34 +233,3 @@ public class Marker : GenericMarker {
     }
   }
 }
-
-//func associatedObject<ValueType: AnyObject>(base: AnyObject, key: UnsafePointer<UInt8>, initialiser: () -> ValueType) -> ValueType {
-//  if let associated = objc_getAssociatedObject(base, key) as? ValueType {
-//    return associated
-//  }
-//  let associated = initialiser()
-//  objc_setAssociatedObject(base, key, associated, .OBJC_ASSOCIATION_RETAIN)
-//  return associated
-//}
-//
-//func associateObject<ValueType: AnyObject>(base: AnyObject, key: UnsafePointer<UInt8>, value: ValueType) {
-//  objc_setAssociatedObject(base, key, value, .OBJC_ASSOCIATION_RETAIN)
-//}
-//
-//class SizeObj {
-//
-//  let size: CGSize
-//
-//  init(_ s: CGSize) {
-//    size = s
-//  }
-//}
-//
-//class BoolObj {
-//
-//  let bool: Bool
-//
-//  init(_ b: Bool) {
-//    bool = b
-//  }
-//}

--- a/src/Marker.swift
+++ b/src/Marker.swift
@@ -34,7 +34,7 @@ public protocol GenericMarker {
   init(size s: CGSize)
 }
 
-public class Marker : GenericMarker {
+public class Marker : NSObject, GenericMarker {
 
   private static let kPointStyle = "points"
   private static let kLineStyle = "lines"
@@ -147,7 +147,7 @@ public class Marker : GenericMarker {
 
   public var active: Bool {
     didSet {
-      updateStyleString()
+      updateStylePath()
     }
   }
 
@@ -161,7 +161,7 @@ public class Marker : GenericMarker {
     return marker
   }
 
-  public convenience required init() {
+  public convenience required override init() {
     self.init(size: Marker.kDefaultSize)
   }
 

--- a/src/UIColorExtensions.swift
+++ b/src/UIColorExtensions.swift
@@ -1,0 +1,24 @@
+//
+//  UIColorExtensions.swift
+//  ios-sdk
+//
+//  Created by Sarah Lensing on 3/22/17.
+//  Copyright © 2017 Mapzen. All rights reserved.
+//
+import UIKit
+import CoreGraphics
+
+extension UIColor {
+  func hexValue() -> String {
+    var r: CGFloat = 1
+    var g: CGFloat = 1
+    var b: CGFloat = 1
+    var a: CGFloat = 1
+    getRed(&r, green: &g, blue: &b, alpha: &a)
+    let red = Float(r * 255)
+    let green = Float(g * 255)
+    let blue = Float(b * 255)
+    let alpha = Float(a * 255)
+    return String.init(format: "#%02lX%02lX%02lX%02lX", lroundf(red), lroundf(green), lroundf(blue), lroundf(alpha))
+  }
+}


### PR DESCRIPTION
### Overview
Adds `Marker` class which allows developers to set basic properties without having to manipulate style strings. If they would like to do advanced work with style strings or paths, the underlying `TGMarker` class is available

### Proposed Changes
- Adds `Marker` class with properties `size`, `backgroundColor`, and `interactive` to handle updating `stylingString`
- Adds `MarkerType` for common layers: `currentLocation`, `searchPin`, and `routeLine`
- Updates `MapController` to use `Marker`

Closes #221 