### PR TITLE
Add MapzenSearch

### DIFF
--- a/Mapzen-ios-sdk.podspec
+++ b/Mapzen-ios-sdk.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
     cs.dependency 'Pelias', '~> 1.0.0-beta'
     cs.dependency 'OnTheRoad', '~> 1.0.0-beta'
     cs.dependency 'Tangram-es', '~> 0.4.1'
-    cs.source_files = "src/*/*.swift"
+    cs.source_files = ['src/*.swift', 'src/*/*.swift']
     cs.resources = [ 'images/*.png', 'tangram/*' ]
   end
 end

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '9.3'
 use_frameworks!
 
 def shared_pods
-  pod 'Pelias', '~> 1.0.0-beta'
+  pod 'Pelias', :git => 'https://github.com/pelias/pelias-ios-sdk.git', :commit => 'fe87d51'
   pod 'OnTheRoad', :git => 'https://github.com/mapzen/on-the-road_ios.git', :commit => '603fe7a'
   pod 'Tangram-es', '~> 0.5.1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,24 +7,30 @@ PODS:
 
 DEPENDENCIES:
   - OnTheRoad (from `https://github.com/mapzen/on-the-road_ios.git`, commit `603fe7a`)
-  - Pelias (~> 1.0.0-beta)
+  - Pelias (from `https://github.com/pelias/pelias-ios-sdk.git`, commit `fe87d51`)
   - Tangram-es (~> 0.5.1)
 
 EXTERNAL SOURCES:
   OnTheRoad:
     :commit: 603fe7a
     :git: https://github.com/mapzen/on-the-road_ios.git
+  Pelias:
+    :commit: fe87d51
+    :git: https://github.com/pelias/pelias-ios-sdk.git
 
 CHECKOUT OPTIONS:
   OnTheRoad:
     :commit: 603fe7a
     :git: https://github.com/mapzen/on-the-road_ios.git
+  Pelias:
+    :commit: fe87d51
+    :git: https://github.com/pelias/pelias-ios-sdk.git
 
 SPEC CHECKSUMS:
   OnTheRoad: d8027a9d9c5e4c3ec885ada373aa20d28fdcbe1b
-  Pelias: 6bcff7e153cdad93faf07028b6eb124636afdfc7
+  Pelias: b917c7dddeed14f3455162260b893de9711ea1bb
   Tangram-es: 5c558140e072edf59d113fa9d0580c61440a530b
 
-PODFILE CHECKSUM: 16f415eda2ff190a394c5a50e428dbe861ab6258
+PODFILE CHECKSUM: 4a8b8daab305e15229c3bda2a1ea35a532da7aa8
 
 COCOAPODS: 1.2.0

--- a/ios-sdk.xcodeproj/project.pbxproj
+++ b/ios-sdk.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		7D503BCC1E77457A00FDDC4F /* SampleMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D503BCB1E77457A00FDDC4F /* SampleMapViewController.swift */; };
 		7D503BCE1E77468B00FDDC4F /* SampleTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D503BCD1E77468B00FDDC4F /* SampleTableViewController.swift */; };
 		7D503BD01E78944300FDDC4F /* TestTGMarkerPickResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D503BCF1E78944300FDDC4F /* TestTGMarkerPickResult.swift */; };
+		7D5616D91E89C8B600D95E5D /* MapzenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5616D81E89C8B600D95E5D /* MapzenSearch.swift */; };
+		7D5616DD1E8AD01100D95E5D /* MapzenSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5616DC1E8AD01100D95E5D /* MapzenSearchTests.swift */; };
 		7D7847251E6775EA000D56CA /* Dimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7847241E6775EA000D56CA /* Dimensions.swift */; };
 		7D7D49931E7708E5006074EB /* TestSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7D49921E7708E5006074EB /* TestSessionDataTask.swift */; };
 		7D7D49951E7709A1006074EB /* TestUrlSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7D49941E7709A1006074EB /* TestUrlSession.swift */; };
@@ -107,6 +109,8 @@
 		7D503BCB1E77457A00FDDC4F /* SampleMapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleMapViewController.swift; sourceTree = "<group>"; };
 		7D503BCD1E77468B00FDDC4F /* SampleTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleTableViewController.swift; sourceTree = "<group>"; };
 		7D503BCF1E78944300FDDC4F /* TestTGMarkerPickResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTGMarkerPickResult.swift; sourceTree = "<group>"; };
+		7D5616D81E89C8B600D95E5D /* MapzenSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapzenSearch.swift; sourceTree = "<group>"; };
+		7D5616DC1E8AD01100D95E5D /* MapzenSearchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapzenSearchTests.swift; sourceTree = "<group>"; };
 		7D7847241E6775EA000D56CA /* Dimensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dimensions.swift; sourceTree = "<group>"; };
 		7D7D49921E7708E5006074EB /* TestSessionDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSessionDataTask.swift; sourceTree = "<group>"; };
 		7D7D49941E7709A1006074EB /* TestUrlSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUrlSession.swift; sourceTree = "<group>"; };
@@ -410,6 +414,7 @@
 				7DB181541E81B745001F9B49 /* SearchDataObjectsTests.swift */,
 				7DB181561E81B77B001F9B49 /* SearchResponseTests.swift */,
 				7D4122731E84834C009520B7 /* SearchConfigsTests.swift */,
+				7D5616DC1E8AD01100D95E5D /* MapzenSearchTests.swift */,
 			);
 			path = "ios-sdkTests";
 			sourceTree = "<group>";
@@ -417,6 +422,7 @@
 		DBC84EA51C985B6D00EE80D8 /* src */ = {
 			isa = PBXGroup;
 			children = (
+				7D5616D81E89C8B600D95E5D /* MapzenSearch.swift */,
 				7DB1813E1E81B472001F9B49 /* SearchDataConverter.swift */,
 				7DB1813F1E81B472001F9B49 /* SearchDataObjects.swift */,
 				7D7847231E6775EA000D56CA /* dimensions */,
@@ -652,6 +658,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7D5616D91E89C8B600D95E5D /* MapzenSearch.swift in Sources */,
 				DBFB759F1E2046D100CF6173 /* TangramExtensions.swift in Sources */,
 				7DB181491E81B681001F9B49 /* SearchResponse.swift in Sources */,
 				DBFB759D1E20345500CF6173 /* SearchPinsViewController.swift in Sources */,
@@ -686,6 +693,7 @@
 			files = (
 				7D7DAE1D1E60C5C900FFCA6F /* TestApplication.swift in Sources */,
 				7D4122741E84834C009520B7 /* SearchConfigsTests.swift in Sources */,
+				7D5616DD1E8AD01100D95E5D /* MapzenSearchTests.swift in Sources */,
 				7DC7F0941E70C26B009E722B /* TestLocationManager.swift in Sources */,
 				7DC7F0981E71E138009E722B /* TestAnnotationTarget.swift in Sources */,
 				7DB181551E81B745001F9B49 /* SearchDataObjectsTests.swift in Sources */,

--- a/ios-sdkTests/MapzenSearchTests.swift
+++ b/ios-sdkTests/MapzenSearchTests.swift
@@ -1,0 +1,276 @@
+//
+//  MapzenSearchTests.swift
+//  ios-sdk
+//
+//  Created by Sarah Lensing on 3/28/17.
+//  Copyright © 2017 Mapzen. All rights reserved.
+//
+
+import XCTest
+@testable import ios_sdk
+import Pelias
+
+public class MapzenSearchTests : XCTestCase {
+
+  let mapzenSearch = MapzenSearch.sharedInstance
+  let peliasSearchManager = PeliasSearchManager.sharedInstance
+
+  func testAutocompleteTimeDelay() {
+    mapzenSearch.autocompleteTimeDelay = 3
+    XCTAssertEqual(3, mapzenSearch.autocompleteTimeDelay)
+    XCTAssertEqual(3, peliasSearchManager.autocompleteTimeDelay)
+  }
+
+  func testBaseUrl() {
+    let defaultBaseUrl = URL.init(string: Constants.URL.base)
+    XCTAssertEqual(mapzenSearch.baseUrl, defaultBaseUrl)
+    XCTAssertEqual(peliasSearchManager.baseUrl, defaultBaseUrl)
+
+    let baseUrl = URL.init(string: "https://search.custom.com")!
+    mapzenSearch.baseUrl = baseUrl
+    XCTAssertEqual(mapzenSearch.baseUrl, baseUrl)
+    XCTAssertEqual(peliasSearchManager.baseUrl, baseUrl)
+  }
+
+  func testQueryItems() {
+    let items = [URLQueryItem.init(name: "test", value: "val")]
+    mapzenSearch.urlQueryItems = items
+    XCTAssertEqual(mapzenSearch.urlQueryItems!, items)
+    XCTAssertEqual(peliasSearchManager.urlQueryItems!, items)
+  }
+
+  func testSearchQuery() {
+    let config = SearchConfig.init(searchText: "test") { (response) in
+      //
+    }
+    let operation = mapzenSearch.search(config)
+    XCTAssertNotNil(operation)
+  }
+
+  func testReverseQuery() {
+    let config = ReverseConfig.init(point: GeoPoint.init(latitude: 40, longitude: 40)) { (response) in
+      //
+    }
+    let operation = mapzenSearch.reverseGeocode(config)
+    XCTAssertNotNil(operation)
+  }
+
+  func testAutocompleteQuery() {
+    let config = AutocompleteConfig.init(searchText: "test", focusPoint: GeoPoint.init(latitude: 40, longitude: 40)) { (response) in
+      //
+    }
+    let operation = mapzenSearch.autocompleteQuery(config)
+    XCTAssertNotNil(operation)
+  }
+
+  func testPlaceQuery() {
+    let config = PlaceConfig.init(places: [PlaceQueryItem.init(placeId: "", dataSource: .openAddresses, layer: .address)]) { (response) in
+      //
+    }
+    let operation = mapzenSearch.placeQuery(config)
+    XCTAssertNotNil(operation)
+  }
+}
+
+class SearchOperationTests : XCTestCase {
+  let operation = SearchOperation.init(TestPeliasOperation())
+
+  func testStart() {
+    operation.start()
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertTrue(peliasOperation.started)
+  }
+
+  func testMain() {
+    operation.main()
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertTrue(peliasOperation.calledMain)
+  }
+
+  func testIsCancelled() {
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertEqual(operation.isCancelled, peliasOperation.isCancelled)
+    operation.cancel()
+    XCTAssertEqual(operation.isCancelled, peliasOperation.isCancelled)
+  }
+
+  func testCancel() {
+    operation.cancel()
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertTrue(peliasOperation.calledCancel)
+  }
+
+  func testIsExecuting() {
+    operation.start()
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertTrue(operation.isExecuting)
+    XCTAssertEqual(operation.isExecuting, peliasOperation.isExecuting)
+    operation.waitUntilFinished()
+    XCTAssertEqual(operation.isExecuting, peliasOperation.isExecuting)
+    XCTAssertEqual(operation.isExecuting, false)
+  }
+
+  func testIsFinished() {
+    operation.start()
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertEqual(operation.isFinished, peliasOperation.isFinished)
+    operation.waitUntilFinished()
+    XCTAssertEqual(operation.isFinished, peliasOperation.isFinished)
+    XCTAssertEqual(operation.isFinished, true)
+  }
+
+  func testIsConcurrent() {
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertEqual(operation.isConcurrent, peliasOperation.isConcurrent)
+  }
+
+  func testIsAsynchronous() {
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertEqual(operation.isAsynchronous, peliasOperation.isAsynchronous)
+  }
+
+  func testIsReady() {
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertEqual(operation.isReady, peliasOperation.isReady)
+  }
+
+  func testAddDependency() {
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    let dep = Operation.init()
+    operation.addDependency(dep)
+    XCTAssertEqual(operation.dependencies, peliasOperation.dependencies)
+    XCTAssertTrue(operation.dependencies.contains(dep))
+    XCTAssertEqual(operation.dependencies.count, 1)
+  }
+
+  func testRemoveDependency() {
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    let dep = Operation.init()
+    operation.addDependency(dep)
+    operation.removeDependency(dep)
+    XCTAssertEqual(operation.dependencies, peliasOperation.dependencies)
+    XCTAssertFalse(operation.dependencies.contains(dep))
+    XCTAssertEqual(operation.dependencies.count, 0)
+  }
+
+  func testDependencies() {
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertEqual(operation.dependencies, peliasOperation.dependencies)
+  }
+
+  func testQueuePriority() {
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertEqual(operation.queuePriority, peliasOperation.queuePriority)
+    operation.queuePriority = .high
+    XCTAssertEqual(operation.queuePriority, peliasOperation.queuePriority)
+    XCTAssertEqual(operation.queuePriority, .high)
+  }
+
+  func testCompletionBlock() {
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    var blockExecuted = false
+    let block = {() in
+      blockExecuted = true
+    }
+    operation.completionBlock = block
+    operation.start()
+    operation.waitUntilFinished()
+    XCTAssertNotNil(operation.completionBlock)
+    XCTAssertNotNil(peliasOperation.completionBlock)
+    XCTAssertTrue(blockExecuted)
+  }
+
+  func testThreadPriority() {
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertEqual(operation.threadPriority, peliasOperation.threadPriority)
+    operation.threadPriority = 2.0
+    XCTAssertEqual(operation.threadPriority, peliasOperation.threadPriority)
+    XCTAssertEqual(operation.threadPriority, 2.0)
+  }
+
+  func testQualityOfService() {
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertEqual(operation.qualityOfService, peliasOperation.qualityOfService)
+    operation.qualityOfService = .background
+    XCTAssertEqual(operation.qualityOfService, peliasOperation.qualityOfService)
+    XCTAssertEqual(operation.qualityOfService, .background)
+  }
+
+  func testName() {
+    let peliasOperation = operation.peliasOperation as! TestPeliasOperation
+    XCTAssertEqual(operation.name, peliasOperation.name)
+    operation.name = "test"
+    XCTAssertEqual(operation.name, peliasOperation.name)
+    XCTAssertEqual(operation.name, "test")
+  }
+
+  class TestPeliasOperation : PeliasOperation {
+
+    var started: Bool = false
+    var calledMain: Bool = false
+    var calledCancel: Bool = false
+    var internalIsFinished: Bool = false
+    var internalIsExecuting: Bool = false
+    var internalThreadPriority: Double = 0.0
+
+    init() {
+      super.init(config: PeliasSearchConfig.init(searchText: "test", completionHandler: { (response) in
+        //
+      }))
+    }
+
+    override func start() {
+      started = true
+      internalIsExecuting = true
+    }
+
+    override func main() {
+      calledMain = true
+    }
+
+    override func cancel() {
+      calledCancel = true
+    }
+
+    override var isFinished: Bool {
+      get {
+        return internalIsFinished
+      }
+    }
+
+    override var isExecuting: Bool {
+      get {
+        return internalIsExecuting
+      }
+    }
+
+    override var threadPriority: Double {
+      get {
+        return internalThreadPriority
+      }
+      set {
+        internalThreadPriority = newValue
+      }
+    }
+
+    override func waitUntilFinished() {
+      internalIsExecuting = false
+      internalIsFinished = true
+      guard let block = completionBlock else { return }
+      block()
+    }
+  }
+}
+
+class SearchErrorTests : XCTestCase {
+
+  let error = SearchError.init(PeliasError.init(code: "code", message: "msg"))
+
+  func testCode() {
+    XCTAssertEqual(error.code, "code")
+  }
+
+  func testMessage() {
+    XCTAssertEqual(error.message, "msg")
+  }
+}

--- a/ios-sdkTests/MapzenSearchTests.swift
+++ b/ios-sdkTests/MapzenSearchTests.swift
@@ -101,7 +101,7 @@ class SearchOperationTests : XCTestCase {
   }
 
   func testIsExecuting() {
-    operation.start()
+    operation.main()
     let peliasOperation = operation.peliasOperation as! TestPeliasOperation
     XCTAssertTrue(operation.isExecuting)
     XCTAssertEqual(operation.isExecuting, peliasOperation.isExecuting)
@@ -111,7 +111,7 @@ class SearchOperationTests : XCTestCase {
   }
 
   func testIsFinished() {
-    operation.start()
+    operation.main()
     let peliasOperation = operation.peliasOperation as! TestPeliasOperation
     XCTAssertEqual(operation.isFinished, peliasOperation.isFinished)
     operation.waitUntilFinished()
@@ -173,7 +173,7 @@ class SearchOperationTests : XCTestCase {
       blockExecuted = true
     }
     operation.completionBlock = block
-    operation.start()
+    operation.main()
     operation.waitUntilFinished()
     XCTAssertNotNil(operation.completionBlock)
     XCTAssertNotNil(peliasOperation.completionBlock)
@@ -226,6 +226,7 @@ class SearchOperationTests : XCTestCase {
 
     override func main() {
       calledMain = true
+      internalIsExecuting = true
     }
 
     override func cancel() {

--- a/ios-sdkTests/SearchResponseTests.swift
+++ b/ios-sdkTests/SearchResponseTests.swift
@@ -11,13 +11,15 @@ import XCTest
 import Pelias
 
 class SearchResponseTests: XCTestCase {
-  let data = Data()
+  var data = Data()
   let urlResponse = URLResponse()
   let error = NSError(domain:"Test", code: 1, userInfo: nil)
   var response: SearchResponse?
+  var peliasResponse:PeliasResponse?
 
   override func setUp() {
-     response = SearchResponse(PeliasResponse(data: data, response: urlResponse, error: error))
+    peliasResponse = PeliasResponse(data: data, response: urlResponse, error: error)
+    response = SearchResponse(peliasResponse!)
   }
 
   func testData() {
@@ -36,8 +38,39 @@ class SearchResponseTests: XCTestCase {
     XCTAssertEqual(response?.error, error)
   }
 
+  func testParsedResponse() {
+    let dict = ["test":"result"]
+    try? data = JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
+    let pr = PeliasResponse(data: data, response: urlResponse, error: error)
+    let r = SearchResponse(pr)
+    XCTAssertEqual(r.parsedResponse?.parsedResponse.allKeys.count, 1)
+    XCTAssertEqual(r.parsedResponse?.parsedResponse["test"] as! String, "result")
+  }
+
+  func testParsedError() {
+    let dict = ["meta":["status_code":1], "results":["error":["message":"test"]]]
+    try? data = JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
+    let pr = PeliasResponse(data: data, response: urlResponse, error: error)
+    let r = SearchResponse(pr)
+    XCTAssertEqual(r.parsedError?.peliasError.code, "1")
+    XCTAssertEqual(r.parsedError?.peliasError.message, "test")
+  }
+
   func testEquals() {
     let otherResponse = SearchResponse(PeliasResponse(data: Data(), response: urlResponse, error: NSError(domain:"Test", code: 1, userInfo: nil)))
     XCTAssertEqual(response, otherResponse)
+  }
+}
+
+class ParsedSearchResponseTests: XCTestCase {
+
+  func testEncodeDecode() {
+    let dict = ["test":"result"]
+    let pr = PeliasSearchResponse(parsedResponse: dict as NSDictionary)
+    let parsedResponse = ParsedSearchResponse.init(pr)
+    ParsedSearchResponse.encode(parsedResponse)
+    let decoded = parsedResponse.decode()
+    XCTAssertEqual(decoded?.peliasResponse.parsedResponse.allKeys.count, 1)
+    XCTAssertEqual(decoded?.peliasResponse.parsedResponse["test"] as! String, "result")
   }
 }

--- a/src/MapViewController.swift
+++ b/src/MapViewController.swift
@@ -340,7 +340,7 @@ open class MapViewController: UIViewController, LocationManagerDelegate {
    
    - returns: A fully formed MapViewController.
   */
-  init() {
+  public init() {
     application = UIApplication.shared
     locationManager = LocationManager.sharedManager
     mapzenManager = MapzenManager.sharedManager

--- a/src/MapzenSearch.swift
+++ b/src/MapzenSearch.swift
@@ -1,0 +1,216 @@
+//
+//  MapzenSearch.swift
+//  Pods
+//
+//  Created by Sarah Lensing on 3/27/17.
+//
+//
+
+import Pelias
+
+public class MapzenSearch : NSObject {
+
+  public static let sharedInstance = MapzenSearch()
+  private let peliasSearchManager = PeliasSearchManager.sharedInstance
+
+  //In seconds
+  public var autocompleteTimeDelay: Double {
+    get {
+      return peliasSearchManager.autocompleteTimeDelay
+    }
+    set(delay) {
+      peliasSearchManager.autocompleteTimeDelay = delay
+    }
+  }
+
+  public var baseUrl: URL {
+    get {
+      return peliasSearchManager.baseUrl
+    }
+    set(url) {
+      peliasSearchManager.baseUrl = url
+    }
+  }
+
+  public var urlQueryItems: [URLQueryItem]? {
+    get {
+      return peliasSearchManager.urlQueryItems
+    }
+    set(queryItems) {
+      peliasSearchManager.urlQueryItems = queryItems
+    }
+  }
+
+  fileprivate override init() {
+  }
+
+  public func search(_ config: SearchConfig) -> SearchOperation {
+    let peliasOperation = peliasSearchManager.performSearch(config.peliasConfig);
+    return SearchOperation.init(peliasOperation)
+  }
+
+  public func reverseGeocode(_ config: ReverseConfig) -> SearchOperation {
+    let peliasOperation = peliasSearchManager.reverseGeocode(config.peliasConfig)
+    return SearchOperation.init(peliasOperation)
+  }
+
+  public func autocompleteQuery(_ config: AutocompleteConfig) -> SearchOperation {
+    let peliasOperation = peliasSearchManager.autocompleteQuery(config.peliasConfig)
+    return SearchOperation.init(peliasOperation)
+  }
+
+  public func placeQuery(_ config: PlaceConfig) -> SearchOperation {
+    let peliasOperation = peliasSearchManager.placeQuery(config.peliasConfig)
+    return SearchOperation.init(peliasOperation)
+  }
+
+  public func cancelOperations() {
+    peliasSearchManager.cancelOperations()
+  }
+}
+
+@objc(MZSearchOperation)
+public class SearchOperation : Operation {
+
+  let peliasOperation: PeliasOperation
+
+  init(_ op: PeliasOperation) {
+    peliasOperation = op
+  }
+
+  override public func start() {
+    peliasOperation.start()
+  }
+
+  override public func main() {
+    peliasOperation.main()
+  }
+
+
+  override public var isCancelled: Bool {
+    get {
+      return peliasOperation.isCancelled
+    }
+  }
+
+  override public func cancel() {
+    peliasOperation.cancel()
+  }
+
+  override public var isExecuting: Bool {
+    get {
+      return peliasOperation.isExecuting
+    }
+  }
+
+  override public var isFinished: Bool {
+    get {
+      return peliasOperation.isFinished
+    }
+  }
+
+  override public var isConcurrent: Bool {
+    get {
+      return peliasOperation.isConcurrent
+    }
+  }
+
+  override public var isAsynchronous: Bool {
+    get {
+      return peliasOperation.isAsynchronous
+    }
+  }
+
+  override public var isReady: Bool {
+    get {
+      return peliasOperation.isReady
+    }
+  }
+
+  override public func addDependency(_ op: Operation) {
+    peliasOperation.addDependency(op)
+  }
+
+  override public func removeDependency(_ op: Operation) {
+    peliasOperation.removeDependency(op)
+  }
+
+  override public var dependencies: [Operation] {
+    get {
+      return peliasOperation.dependencies
+    }
+  }
+
+  override public var queuePriority: Operation.QueuePriority {
+    get {
+      return peliasOperation.queuePriority
+    }
+    set {
+      peliasOperation.queuePriority = newValue
+    }
+  }
+
+  override public var completionBlock: (() -> Swift.Void)? {
+    get {
+      return peliasOperation.completionBlock
+    }
+    set {
+      peliasOperation.completionBlock = newValue
+    }
+  }
+
+  override public func waitUntilFinished() {
+    peliasOperation.waitUntilFinished()
+  }
+
+  override public var threadPriority: Double {
+    get {
+      return peliasOperation.threadPriority
+    }
+    set {
+      peliasOperation.threadPriority = newValue
+    }
+  }
+
+  override public var qualityOfService: QualityOfService {
+    get {
+      return peliasOperation.qualityOfService
+    }
+    set {
+      peliasOperation.qualityOfService = newValue
+    }
+  }
+
+  override public var name: String? {
+    get {
+      return peliasOperation.name
+    }
+    set {
+      peliasOperation.name = newValue
+    }
+  }
+
+}
+
+@objc(MZSearchError)
+public class SearchError: NSObject {
+
+  let peliasError: PeliasError
+
+  public var code: String {
+    get {
+      return peliasError.code
+    }
+  }
+
+  public var message: String {
+    get {
+      return peliasError.message
+    }
+  }
+
+  init(_ error: PeliasError) {
+    peliasError = error
+  }
+}
+

--- a/src/SearchResponse.swift
+++ b/src/SearchResponse.swift
@@ -13,8 +13,15 @@ import Pelias
 public class SearchResponse : NSObject {
   let peliasResponse: PeliasResponse
 
-  //TODO
-  //  private lazy var internalParsedError: MapzenSearchError?
+  private lazy var internalParsedError: SearchError? = { [unowned self] in
+    guard let peliasParsedError = self.peliasResponse.parsedError else { return nil }
+    return SearchError.init(peliasParsedError)
+    }()
+
+  private lazy var internalParsedResponse: ParsedSearchResponse? =  { [unowned self] in
+    guard let peliasParsedResponse = self.peliasResponse.parsedResponse else { return nil }
+    return ParsedSearchResponse.init(peliasParsedResponse)
+  }()
 
   public var data: Data? {
     get {
@@ -34,11 +41,17 @@ public class SearchResponse : NSObject {
     }
   }
 
-  //TODO: create wrapper
-  //  public var parsedResponse: PeliasSearchResponse? {
+  public var parsedResponse: ParsedSearchResponse? {
+    get {
+      return internalParsedResponse
+    }
+  }
 
-  //TODO:
-  //  public var parsedError: MapzenSearchError? {
+  public var parsedError: SearchError? {
+    get {
+      return internalParsedError
+    }
+  }
 
   init(_ response: PeliasResponse) {
     peliasResponse = response
@@ -51,3 +64,29 @@ public class SearchResponse : NSObject {
             response.peliasResponse.error == peliasResponse.error
   }
 }
+
+@objc(MZParsedSearchResponse)
+public class ParsedSearchResponse: NSObject {
+
+  let peliasResponse: PeliasSearchResponse
+
+  public var parsedResponse: NSDictionary {
+    get {
+      return peliasResponse.parsedResponse
+    }
+  }
+
+  init(_ response: PeliasSearchResponse) {
+    peliasResponse = response
+  }
+
+  public static func encode(_ response: ParsedSearchResponse) {
+    PeliasSearchResponse.encode(response.peliasResponse)
+  }
+
+  public func decode() -> ParsedSearchResponse? {
+    guard let decoded = PeliasSearchResponse.decode() else { return nil }
+    return ParsedSearchResponse.init(decoded)
+  }
+}
+


### PR DESCRIPTION
### Overview
Completes objective-c compatibility work by wrapping `PeliasSearchManager` and related operation objects in `MapzenSearch`

### Proposed Changes
- Create main entry point for search via `MapzenSearch`
- Fix pod source files
- Update `Pelias` dependency (https://github.com/pelias/pelias-ios-sdk/pull/58)

Closes #79 
