### PR TITLE
Alter location manager singleton; Sample app updates

### DIFF
--- a/SampleApp/DemoRouteViewController.swift
+++ b/SampleApp/DemoRouteViewController.swift
@@ -9,11 +9,13 @@
 import UIKit
 import OnTheRoad
 import TangramMap
+import CoreLocation
 
 class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDelegate {
   let routeListSegueId = "routeListSegueId"
   var currentRouteResult: OTRRoutingResult?
   var lastRoutingPoint: OTRGeoPoint?
+  var firstTimeZoomToCurrentLocation = true
 
   private var routingLocale = Locale.current {
     didSet {
@@ -34,11 +36,7 @@ class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDeleg
     })
     setupSwitchLocaleBtn()
     let alert = UIAlertController(title: "Tap to Route", message: "Tap anywhere on the map to route!", preferredStyle: .alert)
-    alert.addAction(UIAlertAction(title: "Ok!", style: UIAlertActionStyle.default, handler: { (alertAction) in
-      if LocationManager.sharedManager.currentLocation != nil {
-        _ = self.resetCameraOnCurrentLocation()
-      }
-    }))
+    alert.addAction(UIAlertAction(title: "Ok!", style: UIAlertActionStyle.default, handler: nil))
     present(alert, animated: true, completion: nil)
   }
 
@@ -92,7 +90,7 @@ class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDeleg
     guard let routingController = try? RoutingController.controller() else { return }
     routingController.updateLocale(routingLocale)
 
-    guard let currentLocation = LocationManager.sharedManager.currentLocation  else { return }
+    guard let currentLocation = locationManager.currentLocation  else { return }
     self.lastRoutingPoint = toPoint
     let startingPoint = OTRRoutingPoint(coordinate: OTRGeoPointMake(currentLocation.coordinate.latitude, currentLocation.coordinate.longitude), type: .break)
     let endingPoint = OTRRoutingPoint(coordinate: self.lastRoutingPoint!, type: .break)
@@ -121,4 +119,12 @@ class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDeleg
     requestRoute(toPoint: OTRGeoPoint(coordinate: point))
   }
 
+  //MARK:- Location Delegate Overrides
+  override func locationDidUpdate(_ location: CLLocation) {
+    super.locationDidUpdate(location)
+    if (firstTimeZoomToCurrentLocation) {
+      _ = self.resetCameraOnCurrentLocation()
+      firstTimeZoomToCurrentLocation = false
+    }
+  }
 }

--- a/SampleApp/DemoSearchPinsViewController.swift
+++ b/SampleApp/DemoSearchPinsViewController.swift
@@ -8,6 +8,7 @@
 
 import Pelias
 import TangramMap
+import CoreLocation
 
 class DemoSearchPinsViewController: SampleMapViewController, UITextFieldDelegate, AutocompleteSearchDelegate {
 
@@ -15,6 +16,7 @@ class DemoSearchPinsViewController: SampleMapViewController, UITextFieldDelegate
 
   @IBOutlet weak var displaySearch: UIButton!
   let searchListSegueId = "searchListSegueId"
+  var firstTimeZoomToCurrentLocation = true
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -66,6 +68,13 @@ class DemoSearchPinsViewController: SampleMapViewController, UITextFieldDelegate
 
     animate(toZoomLevel: max(10, self.zoom), withDuration: 1.0)
     animate(toPosition: TGGeoPointMake(location.coordinate.longitude, location.coordinate.latitude), withDuration: 1.0)
-    
+  }
+
+  override func locationDidUpdate(_ location: CLLocation) {
+    super.locationDidUpdate(location)
+    if (firstTimeZoomToCurrentLocation) {
+      _ = self.resetCameraOnCurrentLocation()
+      firstTimeZoomToCurrentLocation = false
+    }
   }
 }

--- a/SampleApp/SampleAutocompleteTableViewController.swift
+++ b/SampleApp/SampleAutocompleteTableViewController.swift
@@ -18,7 +18,7 @@ class SampleAutocompleteTableViewController: SampleTableViewController, UISearch
   
   let searchController = UISearchController(searchResultsController: nil)
   var results: [PeliasMapkitAnnotation]?
-  let manager = LocationManager.sharedManager
+  let manager = LocationManager()
   var currentLocation: CLLocation?
   
   override func viewDidLoad() {

--- a/ios-sdkTests/TestLocationManager.swift
+++ b/ios-sdkTests/TestLocationManager.swift
@@ -13,6 +13,8 @@ class TestLocationManager : LocationManagerProtocol {
 
   open weak var delegate: LocationManagerDelegate?
 
+  var currentLocation: CLLocation?
+
   var requestedInUse = false
 
   func requestAlwaysAuthorization() {

--- a/src/LocationManager.swift
+++ b/src/LocationManager.swift
@@ -32,14 +32,9 @@ import OnTheRoad
 
 /**
  The `LocationManager` class is a wrapper around iOS's built in location subsystem. It provides a simpler interface and customization options.
- 
- - Note: The class is expected to be used as a singleton. As such, access to the class is via the `sharedManager` object.
- */
+  */
 @objc(MZLocationManager)
 open class LocationManager: NSObject, CLLocationManagerDelegate {
-
-  /// The singleton access object.
-  open static let sharedManager = LocationManager()
 
   /// The last received known good location
   open var currentLocation: CLLocation?
@@ -48,7 +43,8 @@ open class LocationManager: NSObject, CLLocationManagerDelegate {
   open weak var delegate: LocationManagerDelegate?
 
   fileprivate let coreLocationManager = CLLocationManager()
-  fileprivate override init(){
+  
+  override init(){
     super.init()
     coreLocationManager.delegate = self
   }
@@ -144,6 +140,7 @@ open class LocationManager: NSObject, CLLocationManagerDelegate {
 /// Protocol for LocationManager's api so that actual implementation can be switched out in testing contexts.
 protocol LocationManagerProtocol : class {
   weak var delegate: LocationManagerDelegate? { get set }
+  var currentLocation: CLLocation? { get set }
 
   func requestAlwaysAuthorization()
   func requestWhenInUseAuthorization()

--- a/src/MZMapViewController.swift
+++ b/src/MZMapViewController.swift
@@ -342,7 +342,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
   */
   public init() {
     application = UIApplication.shared
-    locationManager = LocationManager.sharedManager
+    locationManager = LocationManager()
     mapzenManager = MapzenManager.sharedManager
     super.init(nibName: nil, bundle: nil)
   }
@@ -354,7 +354,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
   */
   required public init?(coder aDecoder: NSCoder) {
     application = UIApplication.shared
-    locationManager = LocationManager.sharedManager
+    locationManager = LocationManager()
     mapzenManager = MapzenManager.sharedManager
     super.init(coder: aDecoder)
   }
@@ -366,7 +366,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
    */
   public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     application = UIApplication.shared
-    locationManager = LocationManager.sharedManager
+    locationManager = LocationManager()
     mapzenManager = MapzenManager.sharedManager
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
   }


### PR DESCRIPTION
### Overview
The location manager as a singleton was causing issues when more than 1 map was allocated in the app. 

### Proposed Changes
This change removes the singleton version and converts it back to a standard object. This enables
nice zooming on all sample app tabs
