### PR TITLE
Synchronize the podfile and podspec to match 1.0 release settings

### DIFF
--- a/Mapzen-ios-sdk.podspec
+++ b/Mapzen-ios-sdk.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name    = 'Mapzen-ios-sdk'
-  s.version = '0.2.0'
+  s.version = '1.0.0'
 
   s.summary           = 'Mapzen iOS SDK'
   s.description       = 'The Mapzen iOS SDK is a thin wrapper that packages up everything you need to use Mapzen services in your iOS applications. It also simplifies setup, installation, API key management, and generally makes your life better.'
@@ -19,9 +19,9 @@ Pod::Spec.new do |s|
   s.default_subspec = 'Core'
 
   s.subspec 'Core' do |cs|
-    cs.dependency 'Pelias', '~> 1.0.0-beta'
-    cs.dependency 'OnTheRoad', '~> 1.0.0-beta'
-    cs.dependency 'Tangram-es', '~> 0.4.1'
+    cs.dependency 'Pelias', '~> 1.0.0'
+    cs.dependency 'OnTheRoad', '~> 1.0.0'
+    cs.dependency 'Tangram-es', '~> 0.5.1'
     cs.source_files = ['src/*.swift', 'src/*/*.swift']
     cs.resources = [ 'images/*.png', 'tangram/*' ]
   end

--- a/Podfile
+++ b/Podfile
@@ -2,8 +2,8 @@ platform :ios, '9.3'
 use_frameworks!
 
 def shared_pods
-  pod 'Pelias', :git => 'https://github.com/pelias/pelias-ios-sdk.git', :commit => 'a48df2'
-  pod 'OnTheRoad', :git => 'https://github.com/mapzen/on-the-road_ios.git', :commit => '603fe7a'
+  pod 'Pelias', '~> 1.0.0'
+  pod 'OnTheRoad', '~> 1.0.0'
   pod 'Tangram-es', '~> 0.5.1'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,36 +1,20 @@
 PODS:
-  - OnTheRoad (0.9.0)
-  - Pelias (1.0.0-beta4):
-    - Pelias/Core (= 1.0.0-beta4)
-  - Pelias/Core (1.0.0-beta4)
+  - OnTheRoad (1.0.0)
+  - Pelias (1.0.0):
+    - Pelias/Core (= 1.0.0)
+  - Pelias/Core (1.0.0)
   - Tangram-es (0.5.1)
 
 DEPENDENCIES:
-  - OnTheRoad (from `https://github.com/mapzen/on-the-road_ios.git`, commit `603fe7a`)
-  - Pelias (from `https://github.com/pelias/pelias-ios-sdk.git`, commit `a48df2`)
+  - OnTheRoad (~> 1.0.0)
+  - Pelias (~> 1.0.0)
   - Tangram-es (~> 0.5.1)
 
-EXTERNAL SOURCES:
-  OnTheRoad:
-    :commit: 603fe7a
-    :git: https://github.com/mapzen/on-the-road_ios.git
-  Pelias:
-    :commit: a48df2
-    :git: https://github.com/pelias/pelias-ios-sdk.git
-
-CHECKOUT OPTIONS:
-  OnTheRoad:
-    :commit: 603fe7a
-    :git: https://github.com/mapzen/on-the-road_ios.git
-  Pelias:
-    :commit: a48df2
-    :git: https://github.com/pelias/pelias-ios-sdk.git
-
 SPEC CHECKSUMS:
-  OnTheRoad: d8027a9d9c5e4c3ec885ada373aa20d28fdcbe1b
-  Pelias: b917c7dddeed14f3455162260b893de9711ea1bb
+  OnTheRoad: 23aeab6259df1bc005457795e255730178c97fdf
+  Pelias: 2e48c190c0e3eb89d7f534df0fad9c0fa3962dd2
   Tangram-es: 5c558140e072edf59d113fa9d0580c61440a530b
 
-PODFILE CHECKSUM: 5b75f0c8a495264d3dc2a11f1883e2451d3e40b9
+PODFILE CHECKSUM: 603229772a662cf926417d4574a68a606acbffeb
 
 COCOAPODS: 1.2.0


### PR DESCRIPTION
### Overview
Our podspec drifted out of date from the sample app's podfile, so this brings that into sync and also updates the sample app to utilize the recently cut releases for Pelias and OnTheRoad.
### Proposed Changes
- Update Mapzen-ios-sdk.podspec to correct dependency versions
- Update sample app's podfile to use production cocoapods