### PR TITLE
Synchronize scene loading with location updates to get desired zooming behavior

### DIFF
--- a/SampleApp/DemoRouteViewController.swift
+++ b/SampleApp/DemoRouteViewController.swift
@@ -15,8 +15,6 @@ class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDeleg
   let routeListSegueId = "routeListSegueId"
   var currentRouteResult: OTRRoutingResult?
   var lastRoutingPoint: OTRGeoPoint?
-  var firstTimeZoomToCurrentLocation = true
-  var sceneDidLoad = false
 
   private var routingLocale = Locale.current {
     didSet {
@@ -112,14 +110,6 @@ class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDeleg
     }
   }
 
-  func shouldZoomToCurrentLocation() {
-    if !sceneDidLoad { return }
-    if lastSetPoint == nil { return }
-    _ = resetCameraOnCurrentLocation()
-    firstTimeZoomToCurrentLocation = false
-  }
-
-
   //MARK:- Single Tap Gesture Recognizer Delegate
   func mapController(_ controller: MZMapViewController, recognizer: UIGestureRecognizer, shouldRecognizeSingleTapGesture location: CGPoint) -> Bool {
     return true
@@ -128,13 +118,5 @@ class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDeleg
   func mapController(_ controller: MZMapViewController, recognizer: UIGestureRecognizer, didRecognizeSingleTapGesture location: CGPoint) {
     let point = tgViewController.screenPosition(toLngLat: location)
     requestRoute(toPoint: OTRGeoPoint(coordinate: point))
-  }
-
-  //MARK:- Location Delegate Overrides
-  override func locationDidUpdate(_ location: CLLocation) {
-    super.locationDidUpdate(location)
-    if (firstTimeZoomToCurrentLocation) {
-      shouldZoomToCurrentLocation()
-    }
   }
 }

--- a/SampleApp/DemoRouteViewController.swift
+++ b/SampleApp/DemoRouteViewController.swift
@@ -16,6 +16,7 @@ class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDeleg
   var currentRouteResult: OTRRoutingResult?
   var lastRoutingPoint: OTRGeoPoint?
   var firstTimeZoomToCurrentLocation = true
+  var sceneDidLoad = false
 
   private var routingLocale = Locale.current {
     didSet {
@@ -31,8 +32,10 @@ class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDeleg
     super.viewDidLoad()
     try? loadStyleAsync(.bubbleWrap, onStyleLoaded: { [unowned self] (style) in
       self.singleTapGestureDelegate = self
+      self.sceneDidLoad = true
       _ = self.showCurrentLocation(true)
       self.showFindMeButon(true)
+      if self.firstTimeZoomToCurrentLocation { self.shouldZoomToCurrentLocation() }
     })
     setupSwitchLocaleBtn()
     let alert = UIAlertController(title: "Tap to Route", message: "Tap anywhere on the map to route!", preferredStyle: .alert)
@@ -109,6 +112,14 @@ class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDeleg
     }
   }
 
+  func shouldZoomToCurrentLocation() {
+    if !sceneDidLoad { return }
+    if lastSetPoint == nil { return }
+    _ = resetCameraOnCurrentLocation()
+    firstTimeZoomToCurrentLocation = false
+  }
+
+
   //MARK:- Single Tap Gesture Recognizer Delegate
   func mapController(_ controller: MZMapViewController, recognizer: UIGestureRecognizer, shouldRecognizeSingleTapGesture location: CGPoint) -> Bool {
     return true
@@ -123,8 +134,7 @@ class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDeleg
   override func locationDidUpdate(_ location: CLLocation) {
     super.locationDidUpdate(location)
     if (firstTimeZoomToCurrentLocation) {
-      _ = self.resetCameraOnCurrentLocation()
-      firstTimeZoomToCurrentLocation = false
+      shouldZoomToCurrentLocation()
     }
   }
 }

--- a/SampleApp/DemoSearchPinsViewController.swift
+++ b/SampleApp/DemoSearchPinsViewController.swift
@@ -17,18 +17,28 @@ class DemoSearchPinsViewController: SampleMapViewController, UITextFieldDelegate
   @IBOutlet weak var displaySearch: UIButton!
   let searchListSegueId = "searchListSegueId"
   var firstTimeZoomToCurrentLocation = true
+  var sceneDidLoad = false
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
     try? loadStyleAsync(.bubbleWrap) { [unowned self] (style) in
+      self.sceneDidLoad = true
       let _ = self.showCurrentLocation(true)
       self.showFindMeButon(true)
+      if self.firstTimeZoomToCurrentLocation { self.shouldZoomToCurrentLocation() }
     }
     
     view.bringSubview(toFront: searchField)
     view.bringSubview(toFront: displaySearch)
     searchField.delegate = self
+  }
+
+  func shouldZoomToCurrentLocation() {
+    if !sceneDidLoad { return }
+    if lastSetPoint == nil { return }
+    _ = resetCameraOnCurrentLocation()
+    firstTimeZoomToCurrentLocation = false
   }
 
   func textFieldShouldReturn(_ textField: UITextField) -> Bool {
@@ -73,8 +83,7 @@ class DemoSearchPinsViewController: SampleMapViewController, UITextFieldDelegate
   override func locationDidUpdate(_ location: CLLocation) {
     super.locationDidUpdate(location)
     if (firstTimeZoomToCurrentLocation) {
-      _ = self.resetCameraOnCurrentLocation()
-      firstTimeZoomToCurrentLocation = false
+      shouldZoomToCurrentLocation()
     }
   }
 }

--- a/SampleApp/DemoSearchPinsViewController.swift
+++ b/SampleApp/DemoSearchPinsViewController.swift
@@ -16,8 +16,6 @@ class DemoSearchPinsViewController: SampleMapViewController, UITextFieldDelegate
 
   @IBOutlet weak var displaySearch: UIButton!
   let searchListSegueId = "searchListSegueId"
-  var firstTimeZoomToCurrentLocation = true
-  var sceneDidLoad = false
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -32,13 +30,6 @@ class DemoSearchPinsViewController: SampleMapViewController, UITextFieldDelegate
     view.bringSubview(toFront: searchField)
     view.bringSubview(toFront: displaySearch)
     searchField.delegate = self
-  }
-
-  func shouldZoomToCurrentLocation() {
-    if !sceneDidLoad { return }
-    if lastSetPoint == nil { return }
-    _ = resetCameraOnCurrentLocation()
-    firstTimeZoomToCurrentLocation = false
   }
 
   func textFieldShouldReturn(_ textField: UITextField) -> Bool {
@@ -78,12 +69,5 @@ class DemoSearchPinsViewController: SampleMapViewController, UITextFieldDelegate
 
     animate(toZoomLevel: max(10, self.zoom), withDuration: 1.0)
     animate(toPosition: TGGeoPointMake(location.coordinate.longitude, location.coordinate.latitude), withDuration: 1.0)
-  }
-
-  override func locationDidUpdate(_ location: CLLocation) {
-    super.locationDidUpdate(location)
-    if (firstTimeZoomToCurrentLocation) {
-      shouldZoomToCurrentLocation()
-    }
   }
 }

--- a/SampleApp/SampleMapViewController.swift
+++ b/SampleApp/SampleMapViewController.swift
@@ -7,10 +7,28 @@
 //
 
 import Foundation
+import CoreLocation
 
 class SampleMapViewController : MZMapViewController {
 
+  var firstTimeZoomToCurrentLocation = true
+  var sceneDidLoad = false
+
   override var prefersStatusBarHidden: Bool {
     return false
+  }
+  func shouldZoomToCurrentLocation() {
+    if !sceneDidLoad { return }
+    if lastSetPoint == nil { return }
+    _ = resetCameraOnCurrentLocation()
+    firstTimeZoomToCurrentLocation = false
+  }
+
+  //MARK:- Location Delegate Overrides
+  override func locationDidUpdate(_ location: CLLocation) {
+    super.locationDidUpdate(location)
+    if (firstTimeZoomToCurrentLocation) {
+      shouldZoomToCurrentLocation()
+    }
   }
 }


### PR DESCRIPTION
### Overview
The sample app should zoom in the first time you launch the Route or Search tabs. However there's a race condition currently preventing that from happening every time, which this PR fixes.
### Proposed Changes
Add additional boolean vars to the route and search view controllers to indicate status of scene loading process and call a central method as a synchronization point so when location updates occur before scene loading completes, we don't attempt to zoom until after scene loading completes. The other direction is also checked, and is handled by an existing variable in MZMapViewController. 