### PR TITLE
Autocomplete crash

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '9.3'
 use_frameworks!
 
 def shared_pods
-  pod 'Pelias', '~> 1.0.0'
+  pod 'Pelias', :git => 'https://github.com/pelias/pelias-ios-sdk.git', :commit => '4b3d8a'
   pod 'OnTheRoad', '~> 1.0.0'
   pod 'Tangram-es', '~> 0.5.1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,14 +7,24 @@ PODS:
 
 DEPENDENCIES:
   - OnTheRoad (~> 1.0.0)
-  - Pelias (~> 1.0.0)
+  - Pelias (from `https://github.com/pelias/pelias-ios-sdk.git`, commit `4b3d8a`)
   - Tangram-es (~> 0.5.1)
+
+EXTERNAL SOURCES:
+  Pelias:
+    :commit: 4b3d8a
+    :git: https://github.com/pelias/pelias-ios-sdk.git
+
+CHECKOUT OPTIONS:
+  Pelias:
+    :commit: 4b3d8a
+    :git: https://github.com/pelias/pelias-ios-sdk.git
 
 SPEC CHECKSUMS:
   OnTheRoad: 23aeab6259df1bc005457795e255730178c97fdf
-  Pelias: 2e48c190c0e3eb89d7f534df0fad9c0fa3962dd2
+  Pelias: 5701bbf3b646849ec62af184f0d54d9588ecbc36
   Tangram-es: 5c558140e072edf59d113fa9d0580c61440a530b
 
-PODFILE CHECKSUM: 603229772a662cf926417d4574a68a606acbffeb
+PODFILE CHECKSUM: bddfc4cc55d534c1396ced24fc8dd6d7888156ee
 
 COCOAPODS: 1.2.0

--- a/SampleApp/SampleAutocompleteTableViewController.swift
+++ b/SampleApp/SampleAutocompleteTableViewController.swift
@@ -56,15 +56,15 @@ class SampleAutocompleteTableViewController: SampleTableViewController, UISearch
   
   func updateSearchResults(for searchController: UISearchController) {
     if let searchText = searchController.searchBar.text, searchController.searchBar.text?.isEmpty == false {
-      var geoPoint = Pelias.GeoPoint(latitude: 40.7312973034393, longitude: -73.99896644276561)
+      var geoPoint = GeoPoint(latitude: 40.7312973034393, longitude: -73.99896644276561)
       if let location = currentLocation {
-        geoPoint = Pelias.GeoPoint(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)
+        geoPoint = GeoPoint(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)
       }
-      let config = PeliasAutocompleteConfig(searchText: searchText, focusPoint: geoPoint, completionHandler: { (autocompleteResponse) -> Void in
-        self.results = autocompleteResponse.parsedMapItems()
+      let config = AutocompleteConfig(searchText: searchText, focusPoint: geoPoint, completionHandler: { (autocompleteResponse) -> Void in
+        self.results = autocompleteResponse.peliasResponse.parsedMapItems()
         self.tableView.reloadData()
       })
-      _ = PeliasSearchManager.sharedInstance.autocompleteQuery(config)
+      _ = MapzenSearch.sharedInstance.autocompleteQuery(config)
     }
   }
   

--- a/SampleApp/SampleAutocompleteTableViewController.swift
+++ b/SampleApp/SampleAutocompleteTableViewController.swift
@@ -61,8 +61,8 @@ class SampleAutocompleteTableViewController: SampleTableViewController, UISearch
         geoPoint = GeoPoint(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)
       }
       let config = AutocompleteConfig(searchText: searchText, focusPoint: geoPoint, completionHandler: { (autocompleteResponse) -> Void in
-        if autocompleteResponse.isGeoJson {
-          self.results = autocompleteResponse.peliasResponse.parsedMapItems()
+        if let parsedItems = autocompleteResponse.peliasResponse.parsedMapItems() {
+          self.results = parsedItems
           self.tableView.reloadData()
         }
       })

--- a/SampleApp/SampleAutocompleteTableViewController.swift
+++ b/SampleApp/SampleAutocompleteTableViewController.swift
@@ -61,8 +61,10 @@ class SampleAutocompleteTableViewController: SampleTableViewController, UISearch
         geoPoint = GeoPoint(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)
       }
       let config = AutocompleteConfig(searchText: searchText, focusPoint: geoPoint, completionHandler: { (autocompleteResponse) -> Void in
-        self.results = autocompleteResponse.peliasResponse.parsedMapItems()
-        self.tableView.reloadData()
+        if autocompleteResponse.isGeoJson {
+          self.results = autocompleteResponse.peliasResponse.parsedMapItems()
+          self.tableView.reloadData()
+        }
       })
       _ = MapzenSearch.sharedInstance.autocompleteQuery(config)
     }

--- a/ios-sdkTests/SearchResponseTests.swift
+++ b/ios-sdkTests/SearchResponseTests.swift
@@ -39,12 +39,12 @@ class SearchResponseTests: XCTestCase {
   }
 
   func testParsedResponse() {
-    let dict = ["test":"result"]
+    let dict = ["type":"FeatureCollection"]
     try? data = JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
     let pr = PeliasResponse(data: data, response: urlResponse, error: error)
     let r = SearchResponse(pr)
-    XCTAssertEqual(r.parsedResponse?.parsedResponse.allKeys.count, 1)
-    XCTAssertEqual(r.parsedResponse?.parsedResponse["test"] as! String, "result")
+    XCTAssertEqual(r.parsedResponse?.parsedResponse.keys.count, 1)
+    XCTAssertEqual(r.parsedResponse?.parsedResponse["type"] as! String, "FeatureCollection")
   }
 
   func testEquals() {
@@ -57,11 +57,11 @@ class ParsedSearchResponseTests: XCTestCase {
 
   func testEncodeDecode() {
     let dict = ["test":"result"]
-    let pr = PeliasSearchResponse(parsedResponse: dict as NSDictionary)
+    let pr = PeliasSearchResponse(parsedResponse: dict)
     let parsedResponse = ParsedSearchResponse.init(pr)
     ParsedSearchResponse.encode(parsedResponse)
     let decoded = parsedResponse.decode()
-    XCTAssertEqual(decoded?.peliasResponse.parsedResponse.allKeys.count, 1)
+    XCTAssertEqual(decoded?.peliasResponse.parsedResponse.keys.count, 1)
     XCTAssertEqual(decoded?.peliasResponse.parsedResponse["test"] as! String, "result")
   }
 }

--- a/src/MapzenSearch.swift
+++ b/src/MapzenSearch.swift
@@ -13,7 +13,7 @@ public class MapzenSearch : NSObject {
   /// Returns the shared 'MapzenSearch' instance.
   public static let sharedInstance = MapzenSearch()
   private let peliasSearchManager = PeliasSearchManager.sharedInstance
-  /// Delay in seconds that the manager should wait between keystrokes to fire a new autocomplete request
+  /// Delay in seconds that the manager should wait between keystrokes to fire a new autocomplete request. Default is 0.3
   public var autocompleteTimeDelay: Double {
     get {
       return peliasSearchManager.autocompleteTimeDelay
@@ -42,6 +42,8 @@ public class MapzenSearch : NSObject {
   }
 
   fileprivate override init() {
+    super.init()
+    autocompleteTimeDelay = 0.3
   }
   /** Perform an asyncronous search request given parameters defined by the search config. Returns the queued operation.
    - parameter config: Object holding search request parameter information.

--- a/src/PeliasMapkitExtensions.swift
+++ b/src/PeliasMapkitExtensions.swift
@@ -123,8 +123,8 @@ public extension PeliasResponse {
   public func parsedMapItems(target: UIResponder?, action: Selector?) -> [PeliasMapkitAnnotation]? {
     //TODO: This should get refactored into eventually being a real GeoJSON decoder, and split out the MapItem creation
     var mapItems = [PeliasMapkitAnnotation]()
-    if let jsonDictionary = parsedResponse?.parsedResponse {
-      guard let featuresArray = jsonDictionary.object(forKey: "features") as? [[String:AnyObject]] else {
+    if let jsonDictionary: Dictionary = parsedResponse?.parsedResponse {
+      guard let featuresArray = jsonDictionary["features"] as? [Dictionary<String, Any>] else {
         return nil
       }
       for feature in featuresArray {

--- a/src/PeliasMapkitExtensions.swift
+++ b/src/PeliasMapkitExtensions.swift
@@ -130,18 +130,20 @@ public extension PeliasResponse {
       for feature in featuresArray {
         //Address Dictionary for Placemark Creation
         let featureProperties = feature["properties"] as? [String:AnyObject]
-        var addressDictionary = [String:String]()
-        addressDictionary[PeliasIDKey] = featureProperties?["id"] as? String
-        addressDictionary[PeliasDataSourceKey] = featureProperties?["source"] as? String
+        var addressDictionary = [String:AnyObject]()
+        addressDictionary[PeliasIDKey] = featureProperties?["id"]
+        addressDictionary[PeliasDataSourceKey] = featureProperties?["source"]
 
         //Coordinate Creation
         let featureGeometry = feature["geometry"] as? [String:AnyObject]
-        let geometryPosition = featureGeometry?["coordinates"] as! [Double]
-        let coordinate = CLLocationCoordinate2DMake(geometryPosition[1], geometryPosition[0])
+        let geometryPosition = featureGeometry?["coordinates"] as? [Double]
+        let lat = geometryPosition?[1] ?? 0.0
+        let lng = geometryPosition?[0] ?? 0.0
+        let coordinate = CLLocationCoordinate2DMake(lat, lng)
 
         //MKPlacemark
         let name = featureProperties?["label"] as? String
-        let mapAnnotation = PeliasMapkitAnnotation(coordinate: coordinate, title: name, subtitle: nil, data: addressDictionary as [String : AnyObject]?)
+        let mapAnnotation = PeliasMapkitAnnotation(coordinate: coordinate, title: name, subtitle: nil, data: addressDictionary)
         if let target = target, let action = action {
           mapAnnotation.setTarget(target: target, action: action)
         }

--- a/src/PeliasMapkitExtensions.swift
+++ b/src/PeliasMapkitExtensions.swift
@@ -124,21 +124,23 @@ public extension PeliasResponse {
     //TODO: This should get refactored into eventually being a real GeoJSON decoder, and split out the MapItem creation
     var mapItems = [PeliasMapkitAnnotation]()
     if let jsonDictionary = parsedResponse?.parsedResponse {
-      let featuresArray = jsonDictionary["features"] as! [[String:AnyObject]]
+      guard let featuresArray = jsonDictionary.object(forKey: "features") as? [[String:AnyObject]] else {
+        return nil
+      }
       for feature in featuresArray {
         //Address Dictionary for Placemark Creation
-        let featureProperties = feature["properties"] as! [String:AnyObject]
+        let featureProperties = feature["properties"] as? [String:AnyObject]
         var addressDictionary = [String:String]()
-        addressDictionary[PeliasIDKey] = featureProperties["id"] as? String
-        addressDictionary[PeliasDataSourceKey] = featureProperties["source"] as? String
+        addressDictionary[PeliasIDKey] = featureProperties?["id"] as? String
+        addressDictionary[PeliasDataSourceKey] = featureProperties?["source"] as? String
 
         //Coordinate Creation
-        let featureGeometry = feature["geometry"] as! [String:AnyObject]
-        let geometryPosition = featureGeometry["coordinates"] as! [Double]
+        let featureGeometry = feature["geometry"] as? [String:AnyObject]
+        let geometryPosition = featureGeometry?["coordinates"] as! [Double]
         let coordinate = CLLocationCoordinate2DMake(geometryPosition[1], geometryPosition[0])
 
         //MKPlacemark
-        let name = featureProperties["label"] as? String
+        let name = featureProperties?["label"] as? String
         let mapAnnotation = PeliasMapkitAnnotation(coordinate: coordinate, title: name, subtitle: nil, data: addressDictionary as [String : AnyObject]?)
         if let target = target, let action = action {
           mapAnnotation.setTarget(target: target, action: action)

--- a/src/SearchResponse.swift
+++ b/src/SearchResponse.swift
@@ -12,12 +12,30 @@ import Pelias
 /// Represents a response for a request executed by 'MapzenSearch'
 @objc(MZSearchResponse)
 public class SearchResponse : NSObject {
+
   let peliasResponse: PeliasResponse
 
   private lazy var internalParsedResponse: ParsedSearchResponse? =  { [unowned self] in
     guard let peliasParsedResponse = self.peliasResponse.parsedResponse else { return nil }
     return ParsedSearchResponse.init(peliasParsedResponse)
   }()
+
+  private static let validTypes: Set = ["Point", "MultiPoint", "LineString", "MultiLineString", "Polygon", "MultiPolygon", "GeometryCollection", "Feature", "FeatureCollection"]
+
+  private lazy var internalIsGeoJson: Bool = { [unowned self] in
+    guard let parsedResponse = self.internalParsedResponse else { return false }
+    let dict = parsedResponse.parsedResponse
+    guard let type = dict["type"] as? String else { return false }
+    return SearchResponse.validTypes.contains(type)
+  }()
+
+  /// Is the parsed response valid geojson
+  public var isGeoJson: Bool {
+    get {
+      return internalIsGeoJson
+    }
+  }
+
   /// The raw response data
   public var data: Data? {
     get {

--- a/src/SearchResponse.swift
+++ b/src/SearchResponse.swift
@@ -62,7 +62,7 @@ public class ParsedSearchResponse: NSObject {
 
   let peliasResponse: PeliasSearchResponse
 
-  public var parsedResponse: NSDictionary {
+  public var parsedResponse: Dictionary<String, Any> {
     get {
       return peliasResponse.parsedResponse
     }

--- a/src/SearchResponse.swift
+++ b/src/SearchResponse.swift
@@ -20,22 +20,6 @@ public class SearchResponse : NSObject {
     return ParsedSearchResponse.init(peliasParsedResponse)
   }()
 
-  private static let validTypes: Set = ["Point", "MultiPoint", "LineString", "MultiLineString", "Polygon", "MultiPolygon", "GeometryCollection", "Feature", "FeatureCollection"]
-
-  private lazy var internalIsGeoJson: Bool = { [unowned self] in
-    guard let parsedResponse = self.internalParsedResponse else { return false }
-    let dict = parsedResponse.parsedResponse
-    guard let type = dict["type"] as? String else { return false }
-    return SearchResponse.validTypes.contains(type)
-  }()
-
-  /// Is the parsed response valid geojson
-  public var isGeoJson: Bool {
-    get {
-      return internalIsGeoJson
-    }
-  }
-
   /// The raw response data
   public var data: Data? {
     get {


### PR DESCRIPTION
### Overview
Fixes crash in sample when executing autocomplete queries at a rate faster than the allowed queries per minute

### Proposed Changes
- Adds default query delay of 0.3 seconds to `MapzenSearch`
- Updates sample app to use `MapzenSearch`
- Adds method to determine if response is valid geojson (so that developer can ignore apiaxle errors returned until this is implemented: https://github.com/pelias/pelias-ios-sdk/issues/4)
- Fixes abrupt clearing of autocomplete result list when rate limit hit

Closes #273 