### PR TITLE
Update autocomplete rate limit to 1 query per second

### DIFF
--- a/SampleApp/SampleAutocompleteTableViewController.swift
+++ b/SampleApp/SampleAutocompleteTableViewController.swift
@@ -61,6 +61,7 @@ class SampleAutocompleteTableViewController: SampleTableViewController, UISearch
         geoPoint = GeoPoint(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)
       }
       let config = AutocompleteConfig(searchText: searchText, focusPoint: geoPoint, completionHandler: { (autocompleteResponse) -> Void in
+        print("Error:\(String(describing: autocompleteResponse.error))")
         if let parsedItems = autocompleteResponse.peliasResponse.parsedMapItems() {
           self.results = parsedItems
           self.tableView.reloadData()

--- a/src/MapzenSearch.swift
+++ b/src/MapzenSearch.swift
@@ -43,7 +43,7 @@ public class MapzenSearch : NSObject {
 
   fileprivate override init() {
     super.init()
-    autocompleteTimeDelay = 0.3
+    autocompleteTimeDelay = 1.0
   }
   /** Perform an asyncronous search request given parameters defined by the search config. Returns the queued operation.
    - parameter config: Object holding search request parameter information.


### PR DESCRIPTION
### Proposed Changes
This change updates the rate limit to a higher default to account for fast typers and the standard query per second rate limits imposed by Mapzen Search. It also adds an error print out to the sample app (which is what showcased the above issue). 