### PR TITLE
Bump podspec & podfile to use the 1.0.1 pelias release

### DIFF
--- a/Mapzen-ios-sdk.podspec
+++ b/Mapzen-ios-sdk.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.default_subspec = 'Core'
 
   s.subspec 'Core' do |cs|
-    cs.dependency 'Pelias', '~> 1.0.0'
+    cs.dependency 'Pelias', '~> 1.0.1'
     cs.dependency 'OnTheRoad', '~> 1.0.0'
     cs.dependency 'Tangram-es', '~> 0.5.1'
     cs.source_files = ['src/*.swift', 'src/*/*.swift']

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '9.3'
 use_frameworks!
 
 def shared_pods
-  pod 'Pelias', :git => 'https://github.com/pelias/pelias-ios-sdk.git', :commit => '487b0d'
+  pod 'Pelias', '~> 1.0.1'
   pod 'OnTheRoad', '~> 1.0.0'
   pod 'Tangram-es', '~> 0.5.1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,33 +1,23 @@
 PODS:
   - HockeySDK/CrashOnlyLib (4.1.4)
   - OnTheRoad (1.0.0)
-  - Pelias (1.0.0):
-    - Pelias/Core (= 1.0.0)
-  - Pelias/Core (1.0.0)
+  - Pelias (1.0.1):
+    - Pelias/Core (= 1.0.1)
+  - Pelias/Core (1.0.1)
   - Tangram-es (0.5.1)
 
 DEPENDENCIES:
   - HockeySDK/CrashOnlyLib (~> 4.1.4)
   - OnTheRoad (~> 1.0.0)
-  - Pelias (from `https://github.com/pelias/pelias-ios-sdk.git`, commit `487b0d`)
+  - Pelias (~> 1.0.1)
   - Tangram-es (~> 0.5.1)
-
-EXTERNAL SOURCES:
-  Pelias:
-    :commit: 487b0d
-    :git: https://github.com/pelias/pelias-ios-sdk.git
-
-CHECKOUT OPTIONS:
-  Pelias:
-    :commit: 487b0d
-    :git: https://github.com/pelias/pelias-ios-sdk.git
 
 SPEC CHECKSUMS:
   HockeySDK: 78a3f8bb9100277b531defc56c970369a3ca267a
   OnTheRoad: 23aeab6259df1bc005457795e255730178c97fdf
-  Pelias: 5701bbf3b646849ec62af184f0d54d9588ecbc36
+  Pelias: e32abfaf0c0de756d60bf4283d17c3e8e047d87d
   Tangram-es: 5c558140e072edf59d113fa9d0580c61440a530b
 
-PODFILE CHECKSUM: d4a1467be03435c9eef776a57ac3ac7e3216cf1c
+PODFILE CHECKSUM: 23f8817d0a0ff61328328709eee275a736f5abfe
 
 COCOAPODS: 1.2.0


### PR DESCRIPTION
### Overview
Updates the Podspec and sample app podfile to use https://github.com/pelias/pelias-ios-sdk/releases/tag/v1.0.1
