### PR TITLE
Assert if no api key set in sample

### DIFF
--- a/SampleApp/AppDelegate.swift
+++ b/SampleApp/AppDelegate.swift
@@ -17,7 +17,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
     startCrashReporter()
-    MapzenManager.sharedManager.apiKey = getEnvironmentVariable(key: "MAPZEN_API_KEY")
+    let apiKey = getEnvironmentVariable(key: "MAPZEN_API_KEY")
+    assert(apiKey.contains("mapzen-"), "Set your Mapzen API key in the scheme by adding a MAPZEN_API_KEY environment variable.")
+    MapzenManager.sharedManager.apiKey = apiKey
     return true
   }
 


### PR DESCRIPTION
### Overview
Requires users to set an API key in the sample app

