### PR TITLE
Update documentation to align with parameters

### DIFF
--- a/MapzenSDK/MZMapViewController.swift
+++ b/MapzenSDK/MZMapViewController.swift
@@ -542,7 +542,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
    Loads a map style synchronously on the main thread. Use the async methods instead of these in production apps.
 
    - parameter style: The map style to load.
-   - parameter locale: The locale to use for the map's language.
+   - parameter l: The locale to use for the map's language.
    - parameter sceneUpdates: The scene updates to make while loading the map style.
    - throws: A MZError `apiKeyNotSet` error if an API Key has not been sent on the MapzenManager class.
    */
@@ -560,7 +560,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
    Loads the map style asynchronously. Recommended for production apps. If you have scene updates to apply, either use the other version of this method that allows you to pass in scene updates during load, or wait until onSceneLoaded is called to apply those updates.
    
    - parameter style: The map style to load.
-   - parameter onSceneLoaded: Closure called on scene loaded.
+   - parameter onStyleLoaded: Closure called on scene loaded.
    - throws: A MZError `apiKeyNotSet` error if an API Key has not been sent on the MapzenManager class.
   */
   open func loadStyleAsync(_ style: MapStyle, onStyleLoaded: OnStyleLoaded?) throws {
@@ -572,7 +572,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
 
    - parameter style: The map style to load.
    - parameter locale: The locale to use for the map's language.
-   - parameter onSceneLoaded: Closure called on scene loaded.
+   - parameter onStyleLoaded: Closure called on scene loaded.
    - throws: A MZError `apiKeyNotSet` error if an API Key has not been sent on the MapzenManager class.
    */
   open func loadStyleAsync(_ style: MapStyle, locale: Locale, onStyleLoaded: OnStyleLoaded?) throws {
@@ -584,7 +584,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
    
    - parameter style: The map style to load.
    - parameter sceneUpdates: The scene updates to make while loading the map style.
-   - parameter onSceneLoaded: Closure called on scene loaded.
+   - parameter onStyleLoaded: Closure called on scene loaded.
    - throws: A MZError `apiKeyNotSet` error if an API Key has not been sent on the MapzenManager class.
    */
   open func loadStyleAsync(_ style: MapStyle, sceneUpdates: [TGSceneUpdate], onStyleLoaded: OnStyleLoaded?) throws {
@@ -601,9 +601,9 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
    Loads the map style asynchronously. Recommended for production apps. If you have scene updates to apply, either pass in the scene updates at the initial call, or wait until onSceneLoaded is called to apply those updates.
 
    - parameter style: The map style to load.
-   - parameter locale: The locale to use for the map's language.
+   - parameter l: The locale to use for the map's language.
    - parameter sceneUpdates: The scene updates to make while loading the map style.
-   - parameter onSceneLoaded: Closure called on scene loaded.
+   - parameter onStyleLoaded: Closure called on scene loaded.
    - throws: A MZError `apiKeyNotSet` error if an API Key has not been sent on the MapzenManager class.
    */
   open func loadStyleAsync(_ style: MapStyle, locale l: Locale, sceneUpdates: [TGSceneUpdate], onStyleLoaded: OnStyleLoaded?) throws {

--- a/MapzenSDK/Marker.swift
+++ b/MapzenSDK/Marker.swift
@@ -42,7 +42,7 @@ public protocol GenericPointMarker: GenericMarker {
 
    - parameter coordinates: Coordinates to animate the marker to
    - parameter seconds: Duration in seconds of the animation.
-   - parameter easeType: Easing to use for animation.
+   - parameter ease: Easing to use for animation.
    */
   func setPointEased(_ coordinates: TGGeoPoint, seconds: Float, easeType ease: TGEaseType) -> Bool
 
@@ -57,7 +57,7 @@ public protocol GenericPointIconMarker: GenericGeometricMarker, GenericPointMark
   /**
    Initializes a marker with a given size.
 
-   - parameter size: The size the marker should be.
+   - parameter s: The size the marker should be.
    */
   init(size s: CGSize)
 }
@@ -231,7 +231,7 @@ public class PointMarker : GeometricMarker, GenericPointIconMarker {
 
    - parameter coordinates: Coordinates to animate the marker to
    - parameter seconds: Duration in seconds of the animation.
-   - parameter easeType: Easing to use for animation.
+   - parameter ease: Easing to use for animation.
    */
   public func setPointEased(_ coordinates: TGGeoPoint, seconds: Float, easeType ease: TGEaseType) -> Bool {
     return tgMarker.setPointEased(coordinates, seconds: seconds, easeType: ease)
@@ -256,7 +256,7 @@ public class PointMarker : GeometricMarker, GenericPointIconMarker {
   /**
    Initializes a marker with a given size.
 
-   - parameter size: The size the marker should be.
+   - parameter s: The size the marker should be.
    */
   public required init(size s: CGSize) {
     size = s
@@ -410,7 +410,7 @@ public class SystemPointMarker : Marker, GenericSystemPointMarker {
 
    - parameter coordinates: Coordinates to animate the marker to
    - parameter seconds: Duration in seconds of the animation.
-   - parameter easeType: Easing to use for animation.
+   - parameter ease: Easing to use for animation.
    */
   public func setPointEased(_ coordinates: TGGeoPoint, seconds: Float, easeType ease: TGEaseType) -> Bool {
     return tgMarker.setPointEased(coordinates, seconds: seconds, easeType: ease)
@@ -466,7 +466,7 @@ public class SelectableSystemPointMarker : Marker, GenericSelectableSystemPointM
 
    - parameter coordinates: Coordinates to animate the marker to
    - parameter seconds: Duration in seconds of the animation.
-   - parameter easeType: Easing to use for animation.
+   - parameter ease: Easing to use for animation.
    */
   public func setPointEased(_ coordinates: TGGeoPoint, seconds: Float, easeType ease: TGEaseType) -> Bool {
     return tgMarker.setPointEased(coordinates, seconds: seconds, easeType: ease)

--- a/MapzenSDK/PeliasMapkitExtensions.swift
+++ b/MapzenSDK/PeliasMapkitExtensions.swift
@@ -93,7 +93,7 @@ open class PeliasMapkitAnnotation: NSObject, MKAnnotation {
   /**
    Sets a target for the selector which will be invoked when the annotation is clicked.
    
-   - parameter target: A target to invoke the selector on when the annotation is clicked
+   - parameter actionTarget: A target to invoke the selector on when the annotation is clicked
    - parameter action: An selector to be invoked on the target when the annotation is clicked
    */
   public func setTarget(target actionTarget: UIResponder, action: Selector) {


### PR DESCRIPTION
### Overview
This resolves the warnings in objective-c related to documentation not aligning with parameter names.
### Proposed Changes
We landed on just resolving the documentation issues rather than changing public-facing API since we're post-1.0.0. However we should come back in 1.1.0 and deprecate these functions and properly rename them. 

Fixes #298 