### PR TITLE
Make sample app style switcher work on all maps in sample

### DIFF
--- a/SampleApp/AppDelegate.swift
+++ b/SampleApp/AppDelegate.swift
@@ -15,6 +15,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var window: UIWindow?
 
+  dynamic var selectedMapStyle: MapStyle = .bubbleWrap
+
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
     startCrashReporter()

--- a/SampleApp/DemoMapViewController.swift
+++ b/SampleApp/DemoMapViewController.swift
@@ -30,8 +30,10 @@ class DemoMapViewController:  SampleMapViewController, MapMarkerSelectDelegate {
     super.viewDidLoad()
     setupSwitchStyleBtn()
     setupSwitchLocaleBtn()
+    setupStyleObservance()
     markerSelectDelegate = self
-    try? loadStyleAsync(.bubbleWrap) { [unowned self] (style) in
+    let appDelegate = UIApplication.shared.delegate as! AppDelegate
+    try? loadStyleAsync(appDelegate.selectedMapStyle) { [unowned self] (style) in
       self.styleLoaded = true
       let _ = self.showCurrentLocation(true)
       self.showFindMeButon(true)
@@ -82,10 +84,8 @@ class DemoMapViewController:  SampleMapViewController, MapMarkerSelectDelegate {
   }
 
   private func indicateLoadStyle(style: MapStyle) {
-    activityIndicator.startAnimating()
-    try? loadStyleAsync(style, onStyleLoaded: { [unowned self] (style) in
-      self.activityIndicator.stopAnimating()
-    })
+    let appDelegate = UIApplication.shared.delegate as! AppDelegate
+    appDelegate.selectedMapStyle = style
   }
 
   @objc private func changeMapLanguage() {

--- a/SampleApp/DemoRouteViewController.swift
+++ b/SampleApp/DemoRouteViewController.swift
@@ -26,7 +26,9 @@ class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDeleg
   //MARK:- ViewController life cycle
   override func viewDidLoad() {
     super.viewDidLoad()
-    try? loadStyleAsync(.bubbleWrap, onStyleLoaded: { [unowned self] (style) in
+    let appDelegate = UIApplication.shared.delegate as! AppDelegate
+
+    try? loadStyleAsync(appDelegate.selectedMapStyle, onStyleLoaded: { [unowned self] (style) in
       self.singleTapGestureDelegate = self
       self.sceneDidLoad = true
       _ = self.showCurrentLocation(true)
@@ -34,6 +36,7 @@ class DemoRouteViewController: SampleMapViewController, MapSingleTapGestureDeleg
       if self.firstTimeZoomToCurrentLocation { self.shouldZoomToCurrentLocation() }
     })
     setupSwitchLocaleBtn()
+    setupStyleObservance()
     let alert = UIAlertController(title: "Tap to Route", message: "Tap anywhere on the map to route!", preferredStyle: .alert)
     alert.addAction(UIAlertAction(title: "Ok!", style: UIAlertActionStyle.default, handler: nil))
     present(alert, animated: true, completion: nil)

--- a/SampleApp/DemoSearchPinsViewController.swift
+++ b/SampleApp/DemoSearchPinsViewController.swift
@@ -18,8 +18,9 @@ class DemoSearchPinsViewController: SampleMapViewController, UITextFieldDelegate
 
   override func viewDidLoad() {
     super.viewDidLoad()
+    let appDelegate = UIApplication.shared.delegate as! AppDelegate
 
-    try? loadStyleAsync(.bubbleWrap) { [unowned self] (style) in
+    try? loadStyleAsync(appDelegate.selectedMapStyle) { [unowned self] (style) in
       self.sceneDidLoad = true
       let _ = self.showCurrentLocation(true)
       self.showFindMeButon(true)
@@ -29,6 +30,7 @@ class DemoSearchPinsViewController: SampleMapViewController, UITextFieldDelegate
     view.bringSubview(toFront: searchField)
     view.bringSubview(toFront: displaySearch)
     searchField.delegate = self
+    setupStyleObservance()
   }
 
   func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/SampleApp/SampleMapViewController.swift
+++ b/SampleApp/SampleMapViewController.swift
@@ -8,11 +8,13 @@
 
 import CoreLocation
 import MapzenSDK
+import UIKit
 
 class SampleMapViewController : MZMapViewController {
 
   var firstTimeZoomToCurrentLocation = true
   var sceneDidLoad = false
+  private var myContext = 0
 
   override var prefersStatusBarHidden: Bool {
     return false
@@ -30,5 +32,30 @@ class SampleMapViewController : MZMapViewController {
     if (firstTimeZoomToCurrentLocation) {
       shouldZoomToCurrentLocation()
     }
+  }
+
+  //KVO for MapStyle changes
+
+  func setupStyleObservance() {
+    let appDelegate = UIApplication.shared.delegate as! AppDelegate
+    appDelegate.addObserver(self, forKeyPath:
+      #keyPath(AppDelegate.selectedMapStyle), options: .new, context: &myContext)
+  }
+
+  override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+    if context == &myContext {
+      if (change?[.newKey]) != nil {
+        //TODO: We should probably actually check to see what the incoming change is here. However, since we're only observing one thing (mapstyle changes), I leave that as an exercise to the reader.
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        try? loadStyle(appDelegate.selectedMapStyle)
+      }
+    } else {
+      super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+    }
+  }
+
+  deinit {
+    let appDelegate = UIApplication.shared.delegate as! AppDelegate
+    appDelegate.removeObserver(self, forKeyPath: #keyPath(AppDelegate.selectedMapStyle), context: &myContext)
   }
 }


### PR DESCRIPTION
### Overview
The maps style switcher should update all maps in the sample app so we can look at things like route lines and pin drops in those styles as well!
### Proposed Changes
Adds a shared value on App Delegate to manage the "map style state" across the sample app. An alternative implementation I considered was to use a NSNotification dispatch across the app to indicate style updates. The issue with this is it would make the `DemoMapViewController` code "special" in so far as it doesn't treat its style system the same way as the rest of the view controllers. 

However one could argue the black-magic that is KVO is probably equally as bad. <shrug>

Fixes #305 
