### PR TITLE
Update placeholder text, fix link

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,17 +1,17 @@
 # Getting started
 
 ## 1. Sign up for an API key
-Sign up for an API key from the [Mapzen developer portal](https://mapzen.com/developers). Then, replace `[YOUR_MAPZEN_API_KEY]` in the App Delegate's `applicationDidFinishLaunching:` with your api key:
+Sign up for an API key from the [Mapzen developer portal](https://mapzen.com/documentation/overview/). Then, use it in the App Delegate's `applicationDidFinishLaunching:`:
 
 ```swift
-MapzenManager.sharedManager.apiKey = "[YOUR_MAPZEN_API_KEY]"
+MapzenManager.sharedManager.apiKey = "your-mapzen-api-key"
 ```
 
 ## 2. Add a map to your storyboard
 Adding a Mapzen map to your storyboard is as easy as:
 
 1. Drag a GLKitViewController onto your storyboard canvas
-2. Create a subclass file named, for example: `DemoMapViewController` and set it's super class to be `MZMapViewController`
+2. Create a subclass file named, for example: `DemoMapViewController` and set its super class to be `MZMapViewController`
 3. Back, in the storyboard, change the GLKitViewController's subclass to be `DemoMapViewController`
 
 ## 3. Initialize the map
@@ -21,7 +21,7 @@ _ = try? loadStyleAsync(.bubbleWrap) { (style) in
   // the map is now ready for interaction
 }
 ```
-This will load the house style [Bubble Wrap])(https://github.com/tangrams/bubble-wrap) that's packaged with the SDK
+This will load the house style [Bubble Wrap](https://github.com/tangrams/bubble-wrap) that's packaged with the SDK
 
 
 Your map is now ready to use.


### PR DESCRIPTION
Update the placeholder text as part of https://github.com/mapzen/documentation/issues/310.

I also deleted some text that describes how to use the placeholder text (like replace it with your real key) because the key is already replaced when signed in, and the pop-up over the text will be the call to action for users who are not signed in.

Also fixed link formatting and it's --> its.