### PR TITLE
Add Bike and Transit Overlays

### DIFF
--- a/MapzenSDK/MZMapViewController.swift
+++ b/MapzenSDK/MZMapViewController.swift
@@ -13,13 +13,20 @@ import CoreLocation
 import Pelias
 import OnTheRoad
 
-struct StateReclaimer {
+public struct StateReclaimer {
   public let tilt: Float
   public let rotation: Float
   public let zoom: Float
   public let position: TGGeoPoint
   public let cameraType: TGCameraType
   public let mapStyle: MapStyle
+}
+
+public struct GlobalStyleVars {
+  public static let transitOverlay = "global.sdk_transit_overlay"
+  public static let bikeOverlay = "global.sdk_bike_overlay"
+  public static let apiKey = "global.sdk_mapzen_api_key"
+  public static let uxLanguage = "global.ux_language"
 }
 
 /** 
@@ -207,8 +214,6 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
   //Error Domains for NSError Appeasement
   open static let MapzenGeneralErrorDomain = "MapzenGeneralErrorDomain"
   private static let mapzenRights = "https://mapzen.com/rights/"
-  private static let kGlobalPathApiKey = "global.sdk_mapzen_api_key"
-  private static let kGlobalPathLanguage = "global.ux_language"
 
   private var isCurrentlyVisible = false // We can't rely on things like window being non-nil because page controllers have a non-nil window as they're being rendered off screen
 
@@ -227,6 +232,8 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
   private var locale = Locale.current
   var stateSaver: StateReclaimer?
   var currentStyle: MapStyle = .bubbleWrap
+  var transitOverlayIsShowing = false
+  var bikeOverlayIsShowing = false
 
   /// The camera type we want to use. Defaults to whatever is set in the style sheet.
   open var cameraType: TGCameraType {
@@ -278,6 +285,27 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
     }
   }
 
+  open var showTransitOverlay: Bool {
+    set {
+      tgViewController.queueSceneUpdate(GlobalStyleVars.transitOverlay, withValue: "\(newValue)")
+      tgViewController.applySceneUpdates()
+      transitOverlayIsShowing = newValue
+    }
+    get {
+      return transitOverlayIsShowing
+    }
+  }
+
+  open var showBikeOverlay: Bool {
+    set {
+      tgViewController.queueSceneUpdate(GlobalStyleVars.bikeOverlay, withValue: "\(newValue)")
+      tgViewController.applySceneUpdates()
+      bikeOverlayIsShowing = newValue
+    }
+    get {
+      return bikeOverlayIsShowing
+    }
+  }
   /// Enables / Disables panning on the map
   open var panEnabled = true
 
@@ -1096,7 +1124,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
     }
     var allSceneUpdates = [TGSceneUpdate]()
     allSceneUpdates.append(contentsOf: sceneUpdates)
-    allSceneUpdates.append(TGSceneUpdate(path: MZMapViewController.kGlobalPathApiKey, value: "'\(apiKey)'"))
+    allSceneUpdates.append(TGSceneUpdate(path: GlobalStyleVars.apiKey, value: "'\(apiKey)'"))
     if let language = locale.languageCode {
       allSceneUpdates.append(createLanguageUpdate(language))
     }
@@ -1104,7 +1132,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
   }
 
   private func createLanguageUpdate(_ language: String) -> TGSceneUpdate {
-    return TGSceneUpdate(path: MZMapViewController.kGlobalPathLanguage, value: language)
+    return TGSceneUpdate(path: GlobalStyleVars.uxLanguage, value: language)
   }
 }
 

--- a/MapzenSDK/MZMapViewController.swift
+++ b/MapzenSDK/MZMapViewController.swift
@@ -284,7 +284,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
       return tgViewController.tilt
     }
   }
-
+  /// Show or hide the transit route overlay. Not intended for use at the same time as the bike overlay.
   open var showTransitOverlay: Bool {
     set {
       tgViewController.queueSceneUpdate(GlobalStyleVars.transitOverlay, withValue: "\(newValue)")
@@ -295,7 +295,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
       return transitOverlayIsShowing
     }
   }
-
+  /// Show or hide the bike route overlay. Not intended for use at the same time as the transit overlay.
   open var showBikeOverlay: Bool {
     set {
       tgViewController.queueSceneUpdate(GlobalStyleVars.bikeOverlay, withValue: "\(newValue)")
@@ -1128,6 +1128,16 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
     if let language = locale.languageCode {
       allSceneUpdates.append(createLanguageUpdate(language))
     }
+
+    //Handle restoring the overlay status on scene change
+    if bikeOverlayIsShowing {
+      allSceneUpdates.append(TGSceneUpdate(path: GlobalStyleVars.bikeOverlay, value: "true"))
+    }
+
+    if transitOverlayIsShowing {
+      allSceneUpdates.append(TGSceneUpdate(path: GlobalStyleVars.transitOverlay, value: "true"))
+    }
+    
     return allSceneUpdates
   }
 

--- a/MapzenSDKTests/MapViewControllerTests.swift
+++ b/MapzenSDKTests/MapViewControllerTests.swift
@@ -269,7 +269,7 @@ class MapViewControllerTests: XCTestCase {
     let point = TGGeoPointMake(1.0, 2.0)
     controller.position = point
     //We don't check latitude because of an underlying precision issue with Tangram. More investigation needed.
-    XCTAssertEqualWithAccuracy(controller.position.longitude, point.longitude, accuracy: DBL_EPSILON)
+    XCTAssertEqualWithAccuracy(controller.position.longitude, point.longitude, accuracy: Double.ulpOfOne)
   }
 
   func testLngLatToScreenPosition() {
@@ -405,7 +405,7 @@ class MapViewControllerTests: XCTestCase {
     let _ = try? controller.add([testAnno1, testAnno2])
 
     //Tests
-    let _ = try? controller.removeAnnotations()
+    controller.removeMapAnnotations()
     XCTAssertNil(controller.currentAnnotations[testAnno1])
     XCTAssertNil(controller.currentAnnotations[testAnno2])
   }
@@ -698,12 +698,12 @@ class MapViewControllerTests: XCTestCase {
     controller.reloadTGViewController()
     controller.recreateMap(controller.stateSaver!)
 
-    XCTAssertEqualWithAccuracy(controller.tilt, 1.0, accuracy: FLT_EPSILON)
-    XCTAssertEqualWithAccuracy(controller.rotation, 2.0, accuracy: FLT_EPSILON)
+    XCTAssertEqualWithAccuracy(controller.tilt, 1.0, accuracy: Float.ulpOfOne)
+    XCTAssertEqualWithAccuracy(controller.rotation, 2.0, accuracy: Float.ulpOfOne)
     //We don't check latitude because of a weird underlying issue with Tangram rounding errors on it. Further investigation required
-    XCTAssertEqualWithAccuracy(controller.position.longitude, 1.0, accuracy: DBL_EPSILON)
+    XCTAssertEqualWithAccuracy(controller.position.longitude, 1.0, accuracy: Double.ulpOfOne)
     XCTAssertEqual(controller.cameraType, .flat)
-    XCTAssertEqualWithAccuracy(controller.zoom, 3.0, accuracy: FLT_EPSILON)
+    XCTAssertEqualWithAccuracy(controller.zoom, 3.0, accuracy: Float.ulpOfOne)
     XCTAssertEqual(controller.currentStyle, .cinnabar)
     XCTAssertTrue(controller.shouldShowCurrentLocation)
     XCTAssertFalse(controller.findMeButton.isHidden)

--- a/MapzenSDKTests/MapViewControllerTests.swift
+++ b/MapzenSDKTests/MapViewControllerTests.swift
@@ -183,6 +183,26 @@ class MapViewControllerTests: XCTestCase {
     XCTAssertEqual(apiKeyUpdate?.value, "'\(apiKey)'")
   }
 
+  func testLoadStyleAsyncPreservesBikeOverlay() {
+    controller.showBikeOverlay = true
+    try? controller.loadStyleAsync(.bubbleWrap, onStyleLoaded: nil)
+    tgViewController.sceneUpdates.forEach { (sceneUpdate) in
+      if sceneUpdate.path == GlobalStyleVars.bikeOverlay {
+        XCTAssertEqual(sceneUpdate.value, "true")
+      }
+    }
+  }
+
+  func testLoadStyleAsyncPreservesTransitOverlay() {
+    controller.showTransitOverlay = true
+    try? controller.loadStyleAsync(.bubbleWrap, onStyleLoaded: nil)
+    tgViewController.sceneUpdates.forEach { (sceneUpdate) in
+      if sceneUpdate.path == GlobalStyleVars.transitOverlay {
+        XCTAssertEqual(sceneUpdate.value, "true")
+      }
+    }
+  }
+
   func testCurrentLocaleIsDefault() {
     try? controller.loadStyleAsync(.bubbleWrap, onStyleLoaded: nil)
     XCTAssertEqual(tgViewController.sceneUpdates.last?.path, "global.ux_language")

--- a/MapzenSDKTests/MapViewControllerTests.swift
+++ b/MapzenSDKTests/MapViewControllerTests.swift
@@ -726,6 +726,18 @@ class MapViewControllerTests: XCTestCase {
     controller.removeMarker(marker)
     XCTAssertNil(controller.currentMarkers[marker.tgMarker!])
   }
+
+  func testBikeOverlay() {
+    controller.showBikeOverlay = true
+    XCTAssertTrue(controller.bikeOverlayIsShowing, "Bike Overlay Not Showing")
+    XCTAssertEqual(tgViewController.sceneUpdateComponentPath, GlobalStyleVars.bikeOverlay, "Bike Overlay Scene Update Path Wrong")
+    XCTAssertEqual(tgViewController.sceneUpdateValue, "true", "Bike Overlay Scene Update Value Wrong")
+  }
+
+  func testTransitOverlay() {
+    controller.showTransitOverlay = true
+    XCTAssertTrue(controller.transitOverlayIsShowing, "Transit Overlay Not Showing")
+  }
 }
 
 class TestPanDelegate : MapPanGestureDelegate {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - HockeySDK/CrashOnlyLib (4.1.5)
-  - Mapzen-ios-sdk (1.0.1):
-    - Mapzen-ios-sdk/Core (= 1.0.1)
-  - Mapzen-ios-sdk/Core (1.0.1):
+  - Mapzen-ios-sdk (1.1.0-rc1):
+    - Mapzen-ios-sdk/Core (= 1.1.0-rc1)
+  - Mapzen-ios-sdk/Core (1.1.0-rc1):
     - OnTheRoad (~> 1.0.0)
     - Pelias (~> 1.0.1)
     - Tangram-es (~> 0.7.1)
@@ -22,7 +22,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   HockeySDK: 606b537bbfbe454ee440e92cc93bc634b3c77151
-  Mapzen-ios-sdk: 2fa22dd0c0a2c50fc519933559f3b58fa0b1211d
+  Mapzen-ios-sdk: 8b8ed815abc7d0d17bf908012f59b887702f5558
   OnTheRoad: 23aeab6259df1bc005457795e255730178c97fdf
   Pelias: e32abfaf0c0de756d60bf4283d17c3e8e047d87d
   Tangram-es: 781ed33fd1b023db74182bf6113814b08c9a65f4

--- a/SampleApp/DemoMapViewController.swift
+++ b/SampleApp/DemoMapViewController.swift
@@ -76,6 +76,12 @@ class DemoMapViewController:  SampleMapViewController, MapMarkerSelectDelegate {
     actionSheet.addAction(UIAlertAction.init(title: "Zinc", style: .default, handler: { [unowned self] (action) in
       self.indicateLoadStyle(style: .zinc)
     }))
+    actionSheet.addAction(UIAlertAction(title: "Show / Hide Transit Overlay", style: .default, handler: { [unowned self] (action) in
+      self.showTransitOverlay = !self.showTransitOverlay
+    }))
+    actionSheet.addAction(UIAlertAction(title: "Show / Hide Bike Overlay", style: .default, handler: { [unowned self] (action) in
+      self.showBikeOverlay = !self.showBikeOverlay
+    }))
     actionSheet.addAction(UIAlertAction.init(title: "Cancel", style: .cancel, handler: { [unowned self] (action) in
       self.dismiss(animated: true, completion: nil)
     }))


### PR DESCRIPTION
### Overview
Enables bike and transit overlays as an option in the SDK
### Proposed Changes
- Updates the Sample app to use the latest SDK RC (unpublished currently)
- Adds bike and transit overlay computed properties with tests
- Adds bike and transit overlay as options in the map style selector.

Fixes #316 
Fixes #218 