### PR TITLE
Refactor API key process so search now reacts to API key changes

### DIFF
--- a/MapzenSDK/MapzenManager.swift
+++ b/MapzenSDK/MapzenManager.swift
@@ -18,25 +18,7 @@ open class MapzenManager: NSObject {
   open static let sharedManager = MapzenManager()
 
   /// The Mapzen API key. If this is not set, exceptions will get raised by the various objects in use.
-  open var apiKey: String? {
-    didSet {
-      guard let apiKey = apiKey else {
-        if let queryItems = PeliasSearchManager.sharedInstance.urlQueryItems {
-          for (index, queryItem) in queryItems.enumerated() {
-            if queryItem.name == "api_key" {
-              PeliasSearchManager.sharedInstance.urlQueryItems?.remove(at: index)
-            } // if queryItem
-          } // for (index, queryItem)
-        } // if let queryItems
-        return
-      }
-
-      PeliasSearchManager.sharedInstance.urlQueryItems = [URLQueryItem(name: "api_key", value: apiKey)]
-
-
-
-    } // didSet
-  } // apiKey
+  dynamic open var apiKey: String?
 
   fileprivate override init(){
     super.init()

--- a/MapzenSDKTests/MapzenManagerTests.swift
+++ b/MapzenSDKTests/MapzenManagerTests.swift
@@ -68,7 +68,8 @@ class MapzenManagerTests: XCTestCase {
     MapzenManager.sharedManager.apiKey = "1234"
 
     //Tests
-    guard let queryParams = PeliasSearchManager.sharedInstance.urlQueryItems else {
+    //This now implicitly tests the KVO implementation used under the covers. Unsure if we should make this more explicit or not in the future.
+    guard let queryParams = MapzenSearch.sharedInstance.urlQueryItems else {
       XCTFail("urlQueryItems should be initialized by this point, but aren't")
       return
     }


### PR DESCRIPTION
### Overview
Refactor MapzenSearch to pull API keys from MapzenManager and react to changes

### Proposed Changes

- Alter MapzenSearch to use KVO to watch for API Key changes
- Move query parameter code from MapzenManager to MapzenManager

Fix #331 