### PR TITLE
Update the Sample App to correctly handle empty string API keys

### DIFF
--- a/SampleApp-Objc/AppDelegate.m
+++ b/SampleApp-Objc/AppDelegate.m
@@ -24,7 +24,7 @@
 }
 
 - (NSString *)getEnvironmentVariableForKey:(NSString *)key {
-  if (NSBundle.mainBundle.infoDictionary[key]) {
+  if (NSBundle.mainBundle.infoDictionary[key] && (NSString*)NSBundle.mainBundle.infoDictionary[key] != [NSString stringWithFormat:@""]) {
     return NSBundle.mainBundle.infoDictionary[key];
   }
 


### PR DESCRIPTION
### Overview
The info dictionary returns an empty string (rather than nil) for our API key by default in the objective-c sample. This causes an issue when trying to set environment variables for the API key to be injected. This PR fixes that by adding additional checks for that case.
### Proposed Changes
- Add empty string check to API key checking code. 