### PR TITLE
Update SDK and Sample App to take into account controlling walking overlays

### DIFF
--- a/MapzenSDK/MZMapViewController.swift
+++ b/MapzenSDK/MZMapViewController.swift
@@ -25,6 +25,7 @@ public struct StateReclaimer {
 public struct GlobalStyleVars {
   public static let transitOverlay = "global.sdk_transit_overlay"
   public static let bikeOverlay = "global.sdk_bike_overlay"
+  public static let pathOverlay = "global.sdk_path_overlay"
   public static let apiKey = "global.sdk_mapzen_api_key"
   public static let uxLanguage = "global.ux_language"
 }
@@ -234,6 +235,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
   var currentStyle: MapStyle = .bubbleWrap
   var transitOverlayIsShowing = false
   var bikeOverlayIsShowing = false
+  var walkingOverlayIsShowing = false
 
   /// The camera type we want to use. Defaults to whatever is set in the style sheet.
   open var cameraType: TGCameraType {
@@ -284,7 +286,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
       return tgViewController.tilt
     }
   }
-  /// Show or hide the transit route overlay. Not intended for use at the same time as the bike overlay.
+  /// Show or hide the transit route overlay. Not intended for use at the same time as the bike overlay. Fine to use with the walking network.
   open var showTransitOverlay: Bool {
     set {
       tgViewController.queueSceneUpdate(GlobalStyleVars.transitOverlay, withValue: "\(newValue)")
@@ -306,6 +308,19 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
       return bikeOverlayIsShowing
     }
   }
+
+  /// Show or hide the walking network. Not intended for use at the same time as the bike overlay. Fine for use with the transit overlay
+  open var showWalkingPathOverlay: Bool {
+    set {
+      tgViewController.queueSceneUpdate(GlobalStyleVars.pathOverlay, withValue: "\(newValue)")
+      tgViewController.applySceneUpdates()
+      walkingOverlayIsShowing = newValue
+    }
+    get {
+      return walkingOverlayIsShowing
+    }
+  }
+
   /// Enables / Disables panning on the map
   open var panEnabled = true
 
@@ -1136,6 +1151,10 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
 
     if transitOverlayIsShowing {
       allSceneUpdates.append(TGSceneUpdate(path: GlobalStyleVars.transitOverlay, value: "true"))
+    }
+
+    if walkingOverlayIsShowing {
+      allSceneUpdates.append(TGSceneUpdate(path: GlobalStyleVars.pathOverlay, value: "true"))
     }
     
     return allSceneUpdates

--- a/MapzenSDK/MZMapViewController.swift
+++ b/MapzenSDK/MZMapViewController.swift
@@ -597,6 +597,9 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
     locale = l
     guard let sceneFile = styles.keyForValue(value: style) else { return }
     currentStyle = style
+    if style == .walkabout {
+      showWalkingPathOverlay = true
+    }
     guard let qualifiedSceneFile = Bundle.houseStylesBundle()?.url(forResource: sceneFile, withExtension: "yaml")?.absoluteString else {
       return
     }
@@ -638,6 +641,9 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
     onStyleLoadedClosure = onStyleLoaded
     guard let sceneFile = styles.keyForValue(value: style) else { return }
     currentStyle = style
+    if style == .walkabout {
+      showWalkingPathOverlay = true
+    }
     guard let qualifiedSceneFile = Bundle.houseStylesBundle()?.url(forResource: sceneFile, withExtension: "yaml")?.absoluteString else {
       return
     }
@@ -658,6 +664,9 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
     onStyleLoadedClosure = onStyleLoaded
     guard let sceneFile = styles.keyForValue(value: style) else { return }
     currentStyle = style
+    if style == .walkabout {
+      showWalkingPathOverlay = true
+    }
     try tgViewController.loadSceneFileAsync(sceneFile, sceneUpdates: allSceneUpdates(sceneUpdates))
   }
 

--- a/MapzenSDK/MZMapViewController.swift
+++ b/MapzenSDK/MZMapViewController.swift
@@ -598,7 +598,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
     guard let sceneFile = styles.keyForValue(value: style) else { return }
     currentStyle = style
     if style == .walkabout {
-      showWalkingPathOverlay = true
+      walkingOverlayIsShowing = true
     }
     guard let qualifiedSceneFile = Bundle.houseStylesBundle()?.url(forResource: sceneFile, withExtension: "yaml")?.absoluteString else {
       return
@@ -642,7 +642,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
     guard let sceneFile = styles.keyForValue(value: style) else { return }
     currentStyle = style
     if style == .walkabout {
-      showWalkingPathOverlay = true
+      walkingOverlayIsShowing = true
     }
     guard let qualifiedSceneFile = Bundle.houseStylesBundle()?.url(forResource: sceneFile, withExtension: "yaml")?.absoluteString else {
       return
@@ -665,7 +665,7 @@ open class MZMapViewController: UIViewController, LocationManagerDelegate {
     guard let sceneFile = styles.keyForValue(value: style) else { return }
     currentStyle = style
     if style == .walkabout {
-      showWalkingPathOverlay = true
+      walkingOverlayIsShowing = true
     }
     try tgViewController.loadSceneFileAsync(sceneFile, sceneUpdates: allSceneUpdates(sceneUpdates))
   }

--- a/MapzenSDKTests/MapViewControllerTests.swift
+++ b/MapzenSDKTests/MapViewControllerTests.swift
@@ -203,6 +203,16 @@ class MapViewControllerTests: XCTestCase {
     }
   }
 
+  func testLoadStyleAsyncPreservesWalkOverlay() {
+    controller.showWalkingPathOverlay = true
+    try? controller.loadStyleAsync(.bubbleWrap, onStyleLoaded: nil)
+    tgViewController.sceneUpdates.forEach { (sceneUpdate) in
+      if sceneUpdate.path == GlobalStyleVars.pathOverlay {
+        XCTAssertEqual(sceneUpdate.value, "true")
+      }
+    }
+  }
+
   func testCurrentLocaleIsDefault() {
     try? controller.loadStyleAsync(.bubbleWrap, onStyleLoaded: nil)
     XCTAssertEqual(tgViewController.sceneUpdates.last?.path, "global.ux_language")
@@ -752,6 +762,13 @@ class MapViewControllerTests: XCTestCase {
     XCTAssertTrue(controller.bikeOverlayIsShowing, "Bike Overlay Not Showing")
     XCTAssertEqual(tgViewController.sceneUpdateComponentPath, GlobalStyleVars.bikeOverlay, "Bike Overlay Scene Update Path Wrong")
     XCTAssertEqual(tgViewController.sceneUpdateValue, "true", "Bike Overlay Scene Update Value Wrong")
+  }
+
+  func testWalkingOverlay() {
+    controller.showWalkingPathOverlay = true
+    XCTAssertTrue(controller.walkingOverlayIsShowing, "Walk Overlay Not Showing")
+    XCTAssertEqual(tgViewController.sceneUpdateComponentPath, GlobalStyleVars.pathOverlay, "Walk Overlay Scene Update Path Wrong")
+    XCTAssertEqual(tgViewController.sceneUpdateValue, "true", "Walk Overlay Scene Update Value Wrong")
   }
 
   func testTransitOverlay() {

--- a/SampleApp/DemoMapViewController.swift
+++ b/SampleApp/DemoMapViewController.swift
@@ -81,6 +81,15 @@ class DemoMapViewController:  SampleMapViewController, MapMarkerSelectDelegate {
     }))
     actionSheet.addAction(UIAlertAction(title: "Show / Hide Bike Overlay", style: .default, handler: { [unowned self] (action) in
       self.showBikeOverlay = !self.showBikeOverlay
+      if self.showBikeOverlay == true {
+        self.showWalkingPathOverlay = false
+      }
+    }))
+    actionSheet.addAction(UIAlertAction(title: "Show / Hide Walking Overlay", style: .default, handler: { [unowned self] (action) in
+      self.showWalkingPathOverlay = !self.showWalkingPathOverlay
+      if self.showWalkingPathOverlay == true {
+        self.showBikeOverlay = false
+      }
     }))
     actionSheet.addAction(UIAlertAction.init(title: "Cancel", style: .cancel, handler: { [unowned self] (action) in
       self.dismiss(animated: true, completion: nil)


### PR DESCRIPTION
### Overview
The current SDK and Sample App provide no access to managing the walking path overlays. This conflicts with our Cartography docs which recommends developers enable / disable walking paths when disabling / enabling bike paths (respectively). 
### Proposed Changes
- Add new computed property to manage walk path overlay being enabled
- Tie into the Sample app and enable the sample app to enable / disable walking and biking paths at the same time.
- Unit tests added for new properties. 

Fixes #347 