### PR TITLE
Tangram 0.8 Upgrade Part 2 - Enable Marker Restoration

### DIFF
--- a/MapzenSDK/TangramExtensions.swift
+++ b/MapzenSDK/TangramExtensions.swift
@@ -44,6 +44,14 @@ public extension TGGeoPoint {
   }
 }
 
+extension TGGeoPoint: Equatable {
+  public static func == (lhs: TGGeoPoint, rhs: TGGeoPoint) -> Bool {
+    return
+      lhs.latitude == rhs.latitude &&
+        lhs.longitude == rhs.longitude
+  }
+}
+
 public extension OTRGeoPoint {
   /**
    Creates a OTRGeoPoint from a TGGeoPoint

--- a/MapzenSDKTests/MapViewControllerTests.swift
+++ b/MapzenSDKTests/MapViewControllerTests.swift
@@ -19,7 +19,7 @@ class TestMapViewController: MZMapViewController {
   func lastSetPointValue() -> TGGeoPoint? {
     return lastSetPoint
   }
-  func currentLocationGemValue() -> GenericMarker? {
+  func currentLocationGemValue() -> GenericSystemPointMarker? {
     return currentLocationGem
   }
   func shouldShowCurrentLocationValue() -> Bool {
@@ -790,6 +790,24 @@ class MapViewControllerTests: XCTestCase {
     tgViewController.mockSceneId = sceneId
     controller.showTransitOverlay = true
     XCTAssertEqual(sceneId, controller.latestSceneId)
+  }
+
+  func testCurrentLocationGemRestoration() {
+    _ = controller.showCurrentLocation(true)
+    let marker = controller.currentLocationGemValue()
+    let geoPoint = TGGeoPoint(longitude: 5.0, latitude: 4.0)
+    marker?.point = geoPoint
+    try? controller.loadStyle(.bubbleWrap)
+    XCTAssertEqual(geoPoint, marker!.tgMarker!.point)
+  }
+
+  func testUserMarkersRestoration() {
+    let testMarker = SystemPointMarker(markerType: .droppedPin)
+    let geoPoint = TGGeoPoint(longitude: 5.0, latitude: 4.0)
+    testMarker.point = geoPoint
+    controller.addMarker(testMarker)
+    try? controller.loadStyle(.walkabout)
+    XCTAssertEqual(geoPoint, testMarker.point)
   }
 }
 


### PR DESCRIPTION
### Overview
Tangram 0.8 removes built-in support of marker restoration on scene change / update. This re-enables that for Mapzen SDK users.

Includes minor refactors / code organization.

### Proposed Changes
- Enable marker restoration for current location gem as well as user markers (routes are included in this since they're added by the user).
- New `internal` facing function for restoring markers and moving individual functions into more private scope.
- Refactor single extension into multiple extensions for individual delegate conformance.
- TGGeoPoint `equatable` conformance to make testing easier.

Closes #351 