### PR TITLE
Update Jazzy docs generation to use new xcode shared scheme

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,4 +1,4 @@
-module: ios_sdk
+module: MapzenSDK
 author: Mapzen
 author_url: https://www.mapzen.com/
 output: ./build/ios-docs/
@@ -6,6 +6,6 @@ github_url: https://github.com/mapzen/ios
 copyright: '© 2017 [Mapzen](https://www.mapzen.com/).'
 head: |
     <link rel='shortcut icon' href='https://mapzen.com/common/styleguide/images/favicon.ico' type='image/x-icon' />
-xcodebuild_arguments: [-workspace,ios-sdk.xcworkspace,-scheme,ios-sdk]
+xcodebuild_arguments: [-workspace,ios-sdk.xcworkspace,-scheme,MapzenSDK]
 skip_undocumented: Yes
 clean: true

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - HockeySDK/CrashOnlyLib (4.1.6)
-  - Mapzen-ios-sdk (1.1.0-rc1):
-    - Mapzen-ios-sdk/Core (= 1.1.0-rc1)
-  - Mapzen-ios-sdk/Core (1.1.0-rc1):
+  - Mapzen-ios-sdk (1.1.0):
+    - Mapzen-ios-sdk/Core (= 1.1.0)
+  - Mapzen-ios-sdk/Core (1.1.0):
     - OnTheRoad (~> 1.0.0)
     - Pelias (~> 1.0.2)
     - Tangram-es (~> 0.8.1)
@@ -22,7 +22,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   HockeySDK: 95db557d54489a570dcdefae0d02f98eecc279a3
-  Mapzen-ios-sdk: 67d02ef1638fa7b76da07c99ca382049707fc57a
+  Mapzen-ios-sdk: 7f23b245eebbafe5d57597da5a3e90bc88a0b044
   OnTheRoad: 23aeab6259df1bc005457795e255730178c97fdf
   Pelias: 3cda3c78c6c1882a1163e500c76a1ee35c5e0edd
   Tangram-es: 4d6d08e8d25900899073133756b35b4cfe2e97f7

--- a/ios-sdk.xcodeproj/xcshareddata/xcschemes/MapzenSDK.xcscheme
+++ b/ios-sdk.xcodeproj/xcshareddata/xcschemes/MapzenSDK.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0830"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7D4639E71EB115270074BEC5"
+               BuildableName = "MapzenSDK.framework"
+               BlueprintName = "MapzenSDK"
+               ReferencedContainer = "container:ios-sdk.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7D4639E71EB115270074BEC5"
+            BuildableName = "MapzenSDK.framework"
+            BlueprintName = "MapzenSDK"
+            ReferencedContainer = "container:ios-sdk.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7D4639E71EB115270074BEC5"
+            BuildableName = "MapzenSDK.framework"
+            BlueprintName = "MapzenSDK"
+            ReferencedContainer = "container:ios-sdk.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
### Overview
The existing jazzy docs generation was broken due to changing the layout of the project. This required setting up a new shared scheme to be used.
### Proposed Changes
- Change Jazzy config to point to correct module to build for docs generation
- Add new shared scheme to build docs successfully
- Update Podfile.lock to make cocoapods happy. 