### PR TITLE
Enable Objective-C protocol conformance

### DIFF
--- a/MapzenSDK/LocationManager.swift
+++ b/MapzenSDK/LocationManager.swift
@@ -10,8 +10,9 @@ import UIKit
 import CoreLocation
 import OnTheRoad
 
-/// LocationManagerDelegate Protocol
-@objc public protocol LocationManagerDelegate {
+/// LocationManagerDelegate Protoco
+@objc(MZLocationManagerDelegate)
+public protocol LocationManagerDelegate {
 
   /// The user authorized the application to receive location updates
   @objc optional func authorizationDidSucceed()
@@ -184,6 +185,7 @@ open class LocationManager: NSObject, CLLocationManagerDelegate, LocationManager
 }
 
 /// Protocol for LocationManager's api so that actual implementation can be switched out in testing contexts.
+@objc(MZLocationManagerProtocol)
 public protocol LocationManagerProtocol : class {
   weak var delegate: LocationManagerDelegate? { get set }
   var currentLocation: CLLocation? { get set }

--- a/MapzenSDK/MZMapViewController.swift
+++ b/MapzenSDK/MZMapViewController.swift
@@ -46,6 +46,7 @@ public enum GlobalStyleVars : String {
 }
 
 /// Single Tap Gesture Delegate
+@objc(MZMapSingleTapGestureDelegate)
 public protocol MapSingleTapGestureDelegate : class {
   /**
    Asks the delegate if the map should recognize this single tap and perform default functionality (which is nothing, currently).
@@ -69,6 +70,7 @@ public protocol MapSingleTapGestureDelegate : class {
 }
 
 /// Double Tap Gesture Delegate
+@objc(MZMapDoubleTapGestureDelegate)
 public protocol MapDoubleTapGestureDelegate : class {
   /**
    Asks the delegate if the map should recognize this double tap and perform default functionality (which is nothing, currently).
@@ -92,6 +94,7 @@ public protocol MapDoubleTapGestureDelegate : class {
 }
 
 /// Long Press Gesture Delegate
+@objc(MZMapLongPressGestureDelegate)
 public protocol MapLongPressGestureDelegate : class {
   /**
    Asks the delegate if the map should recognize this long press gesture and perform default functionality (which is nothing, currently).
@@ -115,6 +118,7 @@ public protocol MapLongPressGestureDelegate : class {
 }
 
 /// Map Pan Gesture Delegate
+@objc(MZMapPanGestureDelegate)
 public protocol MapPanGestureDelegate : class {
   /**
    Informs the delegate the map just panned.
@@ -126,6 +130,7 @@ public protocol MapPanGestureDelegate : class {
 }
 
 /// MapPinchGestureDelegate
+@objc(MZMapPinchGestureDelegate)
 public protocol MapPinchGestureDelegate : class {
   /**
    Informs the delegate the map just zoomed via a pinch gesture.
@@ -137,6 +142,7 @@ public protocol MapPinchGestureDelegate : class {
 }
 
 /// MapRotateGestureDelegate
+@objc(MZMapRotateGestureDelegate)
 public protocol MapRotateGestureDelegate : class {
   /**
    Informs the delegate the map just rotated.
@@ -148,6 +154,7 @@ public protocol MapRotateGestureDelegate : class {
 }
 
 /// MapShoveGestureDelegate
+@objc(MZMapShoveGestureDelegate)
 public protocol MapShoveGestureDelegate : class {
   /**
    Informs the delegate the map just shoved.
@@ -159,6 +166,7 @@ public protocol MapShoveGestureDelegate : class {
 }
 
 /// MapFeatureSelectDelegate
+@objc(MZMapFeatureSelectDelegate)
 public protocol MapFeatureSelectDelegate : class {
   /**
    Informs the delegate a feature of the map was just selected.
@@ -171,6 +179,7 @@ public protocol MapFeatureSelectDelegate : class {
 }
 
 /// MapLabelSelectDelegate
+@objc(MZMapLabelSelectDelegate)
 public protocol MapLabelSelectDelegate : class {
   /**
    Informs the delegate a label of the map was just selected
@@ -183,6 +192,7 @@ public protocol MapLabelSelectDelegate : class {
 }
 
 /// MapMarkerSelectDelegate
+@objc(MZMapMarkerSelectDelegate)
 public protocol MapMarkerSelectDelegate : class {
   /**
    Informs the delegate a marker of the map was just selected
@@ -195,6 +205,7 @@ public protocol MapMarkerSelectDelegate : class {
 }
 
 /// MapTileLoadDelegate
+@objc(MZMapTileLoadDelegate)
 public protocol MapTileLoadDelegate : class {
   /**
    Informs the delegate the map has completed loading tile data and is displaying the map.

--- a/MapzenSDK/Themes.swift
+++ b/MapzenSDK/Themes.swift
@@ -14,8 +14,8 @@ import Foundation
  We do however welcome suggestions / improvements to this API on our github at https://github.com/mapzen/ios
  */
 
-
-@objc public protocol StyleSheet : class {
+@objc(MZStyleSheet)
+public protocol StyleSheet : class {
 
   @objc var fileLocation: URL? { get }
   @objc var remoteFileLocation: URL? { get }
@@ -35,6 +35,7 @@ import Foundation
   @objc var availableLabelLevels: Int { get }
 }
 
+@objc(MZBaseStyle)
 open class BaseStyle: NSObject, StyleSheet {
 
   @objc open var detailLevel: Int = 0
@@ -115,6 +116,7 @@ open class BaseStyle: NSObject, StyleSheet {
 }
 
 //MARK:- Bubble Wrap
+@objc(MZBubbleWrapStyle)
 open class BubbleWrapStyle: BaseStyle {
   public override init() {
     super.init()
@@ -157,6 +159,7 @@ open class BubbleWrapStyle: BaseStyle {
 }
 
 //MARK:- Cinnnabar
+@objc(MZCinnabarStyle)
 open class CinnabarStyle: BaseStyle {
   public override init() {
     super.init()
@@ -199,6 +202,7 @@ open class CinnabarStyle: BaseStyle {
 }
 
 //MARK:- Refill
+@objc(MZRefillStyle)
 open class RefillStyle: BaseStyle {
   public override init() {
     super.init()
@@ -253,6 +257,7 @@ open class RefillStyle: BaseStyle {
 }
 
 //MARK:- Zinc
+@objc(MZZincStyle)
 open class ZincStyle: RefillStyle {
   public override init() {
     super.init()
@@ -269,6 +274,7 @@ open class ZincStyle: RefillStyle {
 }
 
 //MARK:- Walkabout
+@objc(MZWalkaboutStyle)
 open class WalkaboutStyle: BaseStyle {
   public override init() {
     super.init()


### PR DESCRIPTION
### Overview
This issue fixes #368 by conforming all protocols (and in most cases renaming) to objective-c syntax guidelines for swift. It also takes care of possible namespace conflicts in the new stylesheet classes.